### PR TITLE
XML Import fix: Reactions were not being instantiated correctly

### DIFF
--- a/gillespy2/gillespy2.py
+++ b/gillespy2/gillespy2.py
@@ -587,8 +587,8 @@ class Reaction:
         self.name = name
         self.annotation = ""
 
-        if rate is None and propensity_function is None:
-            raise ReactionError("You must specify either a mass-action rate or a propensity function")
+        # if rate is None and propensity_function is None:
+        #     raise ReactionError("You must specify either a mass-action rate or a propensity function")
 
         # We might use this flag in the future to automatically generate
         # the propensity function if set to True.
@@ -622,9 +622,11 @@ class Reaction:
         if self.massaction:
             self.type = "mass-action"
             if rate is None:
-                raise ReactionError("Reaction : A mass-action propensity has to have a rate.")
-            self.marate = rate
-            self.create_mass_action()
+                # raise ReactionError("Reaction : A mass-action propensity has to have a rate.")
+                self.marate = None
+            else:
+                self.marate = rate
+                self.create_mass_action()
         else:
             self.type = "customized"
 


### PR DESCRIPTION
Hi,

I discovered a problem with reaction creation in case of model instantiation from XMLs. Here's the error:

>> import gillespy2
>> from gillespy2 import SSACSolver
>> import numpy as np
>> model_doc = gillespy2.StochMLDocument.from_file("/Users/prashantsingh/LocalDocs/code/GillesPy2/examples/vilar_oscillator.xml")
>> model = model_doc.to_model("Vilar")
Traceback (most recent call last):
File "", line 1, in 
File "/Users/prashantsingh/LocalDocs/code/GillesPy2/gillespy2/gillespy2.py", line 906, in to_model
reaction = Reaction(name=name, reactants={}, products={})
File "/Users/prashantsingh/LocalDocs/code/GillesPy2/gillespy2/gillespy2.py", line 591, in init
raise ReactionError("You must specify either a mass-action rate or a propensity function")
gillespy2.gillespy2.ReactionError: You must specify either a mass-action rate or a propensity function

The self.marate property is used at other places, and causes problems if not set to None. My edits are quick (and hopefully not too dirty). Please feel free to formulate a better solution!