### PR TITLE
Model sanitization

### DIFF
--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -58,8 +58,8 @@ def import_SBML(filename, name=None, gillespy_model=None):
 
 
 class Model(object):
-    # reserved names for model species/parameter names.
-    reserved_names = ['S', 'P', 'V']
+    # reserved names for model species/parameter names, volume, and operators.
+    reserved_names = ['S', 'P', 'V', '[', ']', '+', '-', '*', '/', '.', '^']
 
     """
     Representation of a well mixed biochemical model. Contains reactions,
@@ -148,11 +148,13 @@ class Model(object):
 
     def problem_with_name(self, name):
         if name in Model.reserved_names:
-            return ModelError('Name "{}" is one of the names reserved for internal GillesPy use ().'.format(name, Model.reserved_names))
+            return ModelError('Name "{}" is unavailable. It is reserved for internal GillesPy use. Reserved Names: ({}).'.format(name, Model.reserved_names))
         if name in self.listOfSpecies:
             return ModelError('Name "{}" is unavailable. A species with that name exists.'.format(name))
         if name in self.listOfParameters:
             return ModelError('Name "{}" is unavailable. A parameter with that name exists.'.format(name))
+        if name.isdigit():
+            return ModelError('Name "{}" is unavailable. Names must not be numeric strings.'.format(name))
 
     def get_species(self, s_name):
         """

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -240,7 +240,7 @@ class Model(object):
         parameter_names = sorted(list(self.listOfParameters.keys()), key=lambda parameter: -len(parameter))
         for i, name in enumerate(parameter_names):
             if name not in parameter_name_mapping:
-                parameter_name_mapping[name] = 'P[{}]'.format(i)
+                parameter_name_mapping[name] = 'P{}'.format(i)
         return parameter_name_mapping
 
     def get_parameter(self, p_name):

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -808,13 +808,13 @@ class Reaction:
         self.annotation = annotation
 
     def sanitized_propensity_function(self, species_mappings, parameter_mappings):
-        replacements = list(species_mappings.keys()) + list(parameter_mappings.keys())
-        replacements.sort(key=lambda name: -len(name))
+        names = list(species_mappings.keys()) + list(parameter_mappings.keys())
+        names.sort(key=lambda name: -len(name))
+        replacements = [parameter_mappings[name] if name in parameter_mappings else species_mappings[name] for name in names]
         sanitized_propensity = self.propensity_function
-        for name in replacements:
-            replacement = parameter_mappings[name] if name in parameter_mappings else species_mappings[name]
-            sanitized_propensity = sanitized_propensity.replace(name, replacement)
-        return sanitized_propensity
+        for id, name in enumerate(names):
+            sanitized_propensity = sanitized_propensity.replace(name, "{"+str(id)+"}")
+        return sanitized_propensity.format(*replacements)
 
 
 class StochMLDocument():

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -240,7 +240,9 @@ class Model(object):
             for p in params:
                 self.add_parameter(p)
         else:
-            if isinstance(params,Parameter):
+            if isinstance(params, Parameter):
+                if params.name in self.listOfParameters:
+                    raise ParameterError("Can't add parameter. A parameter with that name already exists.")
                 self.listOfParameters[params.name] = params
             else:
                 raise ParameterError("Could not resolve Parameter expression {} to a scalar value.".format(params))

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -16,7 +16,6 @@ from collections import OrderedDict
 from gillespy2.core.gillespySolver import GillesPySolver
 from gillespy2.core.gillespyError import *
 import numpy as np
-import matplotlib.pyplot as plt
 
 pretty_graph = False
 
@@ -59,7 +58,8 @@ def import_SBML(filename, name=None, gillespy_model=None):
 
 class Model(object):
     # reserved names for model species/parameter names, volume, and operators.
-    reserved_names = ['S', 'P', 'V', '[', ']', '+', '-', '*', '/', '.', '^']
+    reserved_names = ['S', 'P', 'vol', 'V']
+    special_characters = ['[', ']', '+', '-', '*', '/', '.', '^']
 
     """
     Representation of a well mixed biochemical model. Contains reactions,
@@ -155,6 +155,9 @@ class Model(object):
             return ModelError('Name "{}" is unavailable. A parameter with that name exists.'.format(name))
         if name.isdigit():
             return ModelError('Name "{}" is unavailable. Names must not be numeric strings.'.format(name))
+        for special_character in Model.special_characters:
+            if special_character in name:
+                return ModelError('Name "{}" is unavailable. Names must not contain special characters: {}.'.format(name, Model.special_characters))
 
     def get_species(self, s_name):
         """
@@ -237,6 +240,8 @@ class Model(object):
         parameter_names = sorted(list(self.listOfParameters.keys()), key=lambda parameter: -len(parameter))
         for i, name in enumerate(parameter_names):
             parameter_name_mapping[name] = 'P[{}]'.format(i)
+        if 'vol' not in parameter_name_mapping:
+            parameter_name_mapping['vol'] = 'V'
         return parameter_name_mapping
 
     def get_parameter(self, p_name):

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -58,7 +58,7 @@ def import_SBML(filename, name=None, gillespy_model=None):
 
 class Model(object):
     # reserved names for model species/parameter names, volume, and operators.
-    reserved_names = ['S', 'P', 'vol', 'V']
+    reserved_names = ['vol']
     special_characters = ['[', ']', '+', '-', '*', '/', '.', '^']
 
     """
@@ -141,8 +141,7 @@ class Model(object):
         :return: the dictionary mapping user species names to their internal GillesPy notation.
         """
         species_name_mapping = {}
-        species_names = sorted(list(self.listOfSpecies.keys()), key=lambda species: -len(species))
-        for i, name in enumerate(species_names):
+        for i, name in enumerate(self.listOfSpecies.keys()):
             species_name_mapping[name] = 'S[{}]'.format(i)
         return species_name_mapping
 
@@ -236,9 +235,8 @@ class Model(object):
         later on by GillesPySolvers evaluating reaction propensity functions.
         :return: the dictionary mapping user parameter names to their internal GillesPy notation.
         """
-        parameter_name_mapping = {'vol' : 'V'}
-        parameter_names = sorted(list(self.listOfParameters.keys()), key=lambda parameter: -len(parameter))
-        for i, name in enumerate(parameter_names):
+        parameter_name_mapping = {'vol': 'V'}
+        for i, name in enumerate(self.listOfParameters.keys()):
             if name not in parameter_name_mapping:
                 parameter_name_mapping[name] = 'P{}'.format(i)
         return parameter_name_mapping

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -236,12 +236,11 @@ class Model(object):
         later on by GillesPySolvers evaluating reaction propensity functions.
         :return: the dictionary mapping user parameter names to their internal GillesPy notation.
         """
-        parameter_name_mapping = {}
+        parameter_name_mapping = {'vol' : 'V'}
         parameter_names = sorted(list(self.listOfParameters.keys()), key=lambda parameter: -len(parameter))
         for i, name in enumerate(parameter_names):
-            parameter_name_mapping[name] = 'P[{}]'.format(i)
-        if 'vol' not in parameter_name_mapping:
-            parameter_name_mapping['vol'] = 'V'
+            if name not in parameter_name_mapping:
+                parameter_name_mapping[name] = 'P[{}]'.format(i)
         return parameter_name_mapping
 
     def get_parameter(self, p_name):

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -130,9 +130,18 @@ class Model(object):
         self.namespace = OrderedDict([])
         for param in self.listOfParameters:
             self.namespace[param] = self.listOfParameters[param].value
-        # Dictionary of expressions that can be evaluated in the scope of this
-        # model.
-        self.expressions = {}
+
+    def sanitized_species_names(self):
+        """
+        Generate a dictionary mapping user chosen species names to simplified formats which will be used
+        later on by GillesPySolvers evaluating reaction propensity functions.
+        :return: the dictionary mapping user species names to their internal GillesPy notation.
+        """
+        species_name_mapping = {}
+        species_names = sorted(list(self.listOfSpecies.keys()), key=lambda species: -len(species))
+        for i, name in enumerate(species_names):
+            species_name_mapping[name] = 'S[{}]'.format(i)
+        return species_name_mapping
 
     def get_species(self, s_name):
         """

--- a/gillespy2/example_models.py
+++ b/gillespy2/example_models.py
@@ -232,7 +232,7 @@ class Example(Model):
         # Initialize the model.
         Model.__init__(self, name="Example")
         # Species
-        S = Species(name='S', initial_value=100)
+        S = Species(name='Sp', initial_value=100)
         self.add_species([S])
         # Parameters
         k1 = Parameter(name='k1', expression=3.0)
@@ -257,7 +257,7 @@ class Tyson2StateOscillator(Model):
         Y = Species(name='Y', initial_value=int(0.85088331 * 300))
         self.add_species([X, Y])
 
-        P = Parameter(name='P', expression=2.0)
+        P = Parameter(name='p', expression=2.0)
         kt = Parameter(name='kt', expression=20.0)
         kd = Parameter(name='kd', expression=1.0)
         a0 = Parameter(name='a0', expression=0.005)

--- a/gillespy2/solvers/cpp/c_base/SimulationTemplate.cpp
+++ b/gillespy2/solvers/cpp/c_base/SimulationTemplate.cpp
@@ -19,7 +19,7 @@ __DEFINE_CONSTANTS__
 
 class PropensityFunction : public IPropensityFunction{
 public:
-  double evaluate(uint reaction_number, uint* state){
+  double evaluate(uint reaction_number, uint* S){
     switch(reaction_number){
 __DEFINE_PROPENSITY__
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,60 @@
+import unittest
+import gillespy2
+from gillespy2.core import gillespyError
+import numpy as np
+
+
+class TestModel(unittest.TestCase):
+    def test_duplicate_parameter_names(self):
+        model = gillespy2.Model()
+        param1 = gillespy2.Parameter('A', expression=0)
+        param2 = gillespy2.Parameter('A', expression=0)
+        model.add_parameter(param1)
+        with self.assertRaises(gillespyError.ModelError):
+            model.add_parameter(param2)
+
+    def test_duplicate_species_names(self):
+        model = gillespy2.Model()
+        species1 = gillespy2.Species('A', initial_value=0)
+        species2 = gillespy2.Species('A', initial_value=0)
+        model.add_species(species1)
+        with self.assertRaises(gillespyError.ModelError):
+            model.add_species(species2)
+
+    def test_duplicate_reaction_name(self):
+        model = gillespy2.Model()
+        rate = gillespy2.Parameter(name='rate', expression=0.5)
+        model.add_parameter(rate)
+        species1 = gillespy2.Species('A', initial_value=0)
+        species2 = gillespy2.Species('B', initial_value=0)
+        model.add_species([species1, species2])
+        reaction1 = gillespy2.Reaction(name="reaction1", reactants={species1: 1}, products={species2: 1}, rate=rate)
+        reaction2 = gillespy2.Reaction(name="reaction1", reactants={species2: 1}, products={species1: 1}, rate=rate)
+        model.add_reaction(reaction1)
+        with self.assertRaises(gillespyError.ModelError):
+            model.add_reaction(reaction2)
+
+    def test_species_parameter_name_substrings(self):
+        model = gillespy2.Model()
+        rate = gillespy2.Parameter(name='rate', expression=0.5)
+        model.add_parameter(rate)
+        species1 = gillespy2.Species('A', initial_value=1)
+        species2 = gillespy2.Species('AA', initial_value=0)
+        model.add_species([species1, species2])
+        reaction1 = gillespy2.Reaction(name="reaction1", reactants={species1: 1}, products={species2: 1}, rate=rate)
+        reaction2 = gillespy2.Reaction(name="reaction2", reactants={species2: 1}, products={species1: 1}, rate=rate)
+        model.add_reaction([reaction1, reaction2])
+        number_points = 11
+        model.timespan(np.linspace(0, 10, number_points))
+        results = model.run(number_of_trajectories=1)[0]
+        self.assertTrue(len(results['time']) == number_points)
+        self.assertTrue(len(results[species1.name]) == number_points)
+        self.assertTrue(len(results[species2.name]) == number_points)
+        self.assertGreater(np.sum(results[species1.name]), 0)
+        self.assertGreater(np.sum(results[species2.name]), 0)
+        self.assertEqual(np.sum(results[species1.name]) + np.sum(results[species2.name]), number_points)
+
+
+
+
+


### PR DESCRIPTION
Refined parameter/species name handling.
- Species/parameter names containing the names of shorter species/parameters no longer causes an issue (Issues #21 and #22). 
- Attempting to add a parameter/species to a model which already contains a parameter/species of the same name now raises the appropriate ModelError (Issue #33).
- Attempting to add a parameter/species with the reserved name 'vol' to a model now raises a ModelError.
- Attempting to add a parameter/species with a name containing mathematical operators/special characters to a model now raises a ModelError.
