### PR TITLE
Update travis file to use run_tests.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ python:
 install:
   - pip install numpy matplotlib seaborn
 script:
-  python -m unittest discover -s test -v
+  python test/run_tests.py
 


### PR DESCRIPTION
Pointing travis to the run_tests.py file instead of running the python discover command itself