### PR TITLE
Fix for Win10 C compiler compatibility issues

### DIFF
--- a/gillespy2/solvers/cpp/c_base/SimulationTemplate.cpp
+++ b/gillespy2/solvers/cpp/c_base/SimulationTemplate.cpp
@@ -3,13 +3,14 @@
 #include <iostream>
 #include <sstream>
 #include <time.h>
+#include <cstdint>
 #include "model.h"
 #include "ssa.h"
 using namespace Gillespy;
 
 //Default values, replaced with command line args
-uint number_trajectories = 0;
-uint number_timesteps = 0;
+uint32_t number_trajectories = 0;
+uint32_t number_timesteps = 0;
 int random_seed = 0;
 double end_time = 0;
 bool seed_time = true;
@@ -19,7 +20,7 @@ __DEFINE_CONSTANTS__
 
 class PropensityFunction : public IPropensityFunction{
 public:
-  double evaluate(uint reaction_number, uint* S){
+  double evaluate(uint32_t reaction_number, uint32_t* S){
     switch(reaction_number){
 __DEFINE_PROPENSITY__
 
@@ -31,7 +32,7 @@ __DEFINE_PROPENSITY__
 
 int main(int argc, char* argv[]){
   std :: vector<std :: string> species_names(s_names, s_names + sizeof(s_names)/sizeof(std :: string));
-  std :: vector<uint> species_populations(populations, populations + sizeof(populations)/sizeof(populations[0]));
+  std :: vector<uint32_t> species_populations(populations, populations + sizeof(populations)/sizeof(populations[0]));
   std :: vector<std :: string> reaction_names(r_names, r_names + sizeof(r_names)/sizeof(std :: string));
   
   Model model(species_names, species_populations, reaction_names);

--- a/gillespy2/solvers/cpp/c_base/SimulationTemplate.cpp
+++ b/gillespy2/solvers/cpp/c_base/SimulationTemplate.cpp
@@ -3,14 +3,13 @@
 #include <iostream>
 #include <sstream>
 #include <time.h>
-#include <cstdint>
 #include "model.h"
 #include "ssa.h"
 using namespace Gillespy;
 
 //Default values, replaced with command line args
-uint32_t number_trajectories = 0;
-uint32_t number_timesteps = 0;
+unsigned int number_trajectories = 0;
+unsigned int number_timesteps = 0;
 int random_seed = 0;
 double end_time = 0;
 bool seed_time = true;
@@ -20,7 +19,7 @@ __DEFINE_CONSTANTS__
 
 class PropensityFunction : public IPropensityFunction{
 public:
-  double evaluate(uint32_t reaction_number, uint32_t* S){
+  double evaluate(unsigned int reaction_number, unsigned int* S){
     switch(reaction_number){
 __DEFINE_PROPENSITY__
 
@@ -32,7 +31,7 @@ __DEFINE_PROPENSITY__
 
 int main(int argc, char* argv[]){
   std :: vector<std :: string> species_names(s_names, s_names + sizeof(s_names)/sizeof(std :: string));
-  std :: vector<uint32_t> species_populations(populations, populations + sizeof(populations)/sizeof(populations[0]));
+  std :: vector<unsigned int> species_populations(populations, populations + sizeof(populations)/sizeof(populations[0]));
   std :: vector<std :: string> reaction_names(r_names, r_names + sizeof(r_names)/sizeof(std :: string));
   
   Model model(species_names, species_populations, reaction_names);

--- a/gillespy2/solvers/cpp/c_base/model.cpp
+++ b/gillespy2/solvers/cpp/c_base/model.cpp
@@ -1,39 +1,38 @@
 #include "model.h"
-#include <cstdint>
 
 namespace Gillespy{
   
-  Model :: Model(std :: vector<std :: string> species_names, std :: vector<uint32_t> species_populations, std :: vector<std :: string> reaction_names):
+  Model :: Model(std :: vector<std :: string> species_names, std :: vector<unsigned int> species_populations, std :: vector<std :: string> reaction_names):
     number_species(species_names.size()),
     number_reactions(reaction_names.size())
   {
     species = std :: make_unique<Species[]>(number_species);
-    for(uint32_t i = 0; i < number_species; i++){
+    for(unsigned int i = 0; i < number_species; i++){
       species[i].id = i;
       species[i].initial_population = species_populations[i];
       species[i].name = species_names[i];
     }
     reactions = std :: make_unique<Reaction[]>(number_reactions);
-    for(uint32_t i = 0; i < number_reactions; i++){
+    for(unsigned int i = 0; i < number_reactions; i++){
       reactions[i].name = reaction_names[i];
       reactions[i].species_change = std :: make_unique<int[]>(number_species);
-      for(uint32_t j = 0; j < number_species; j++){
+      for(unsigned int j = 0; j < number_species; j++){
 	reactions[i].species_change[j] = 0;	
       }
-      reactions[i].affected_reactions = std :: vector<uint32_t>();
+      reactions[i].affected_reactions = std :: vector<unsigned int>();
     }
   }
 
   void Model :: update_affected_reactions(){
     //Clear affected_reactions for each reaction
-    for(uint32_t i = 0; i < number_reactions; i++){
+    for(unsigned int i = 0; i < number_reactions; i++){
       reactions[i].affected_reactions.clear();
     }   
     //Check all reactions for common species changes -> affected reactions
-    for(uint32_t r1 = 0; r1 < number_reactions; r1++){
+    for(unsigned int r1 = 0; r1 < number_reactions; r1++){
       reactions[r1].affected_reactions.push_back(r1);
-      for(uint32_t r2 = r1 + 1; r2 < number_reactions; r2++){
-	for(uint32_t s = 0; s < number_species; s++){
+      for(unsigned int r2 = r1 + 1; r2 < number_reactions; r2++){
+	for(unsigned int s = 0; s < number_species; s++){
 	  if(reactions[r1].species_change[s] != 0 and reactions[r2].species_change[s] != 0){
 	    reactions[r1].affected_reactions.push_back(r2);
 	    reactions[r2].affected_reactions.push_back(r1);
@@ -44,18 +43,18 @@ namespace Gillespy{
   }
 
 
-  Simulation :: Simulation(Model* model, uint32_t number_trajectories, uint32_t number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed) : model(model), end_time(end_time), random_seed(random_seed), number_timesteps(number_timesteps), number_trajectories(number_trajectories), propensity_function(propensity_function){
+  Simulation :: Simulation(Model* model, unsigned int number_trajectories, unsigned int number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed) : model(model), end_time(end_time), random_seed(random_seed), number_timesteps(number_timesteps), number_trajectories(number_trajectories), propensity_function(propensity_function){
     timeline = new double[number_timesteps];
     double timestep_size = end_time/(number_timesteps-1);
-    for(uint32_t i = 0; i < number_timesteps; i++){
+    for(unsigned int i = 0; i < number_timesteps; i++){
       timeline[i] = timestep_size * i;
     }
-    uint32_t trajectory_size = number_timesteps * (model -> number_species);
-    trajectories_1D = new uint32_t[number_trajectories * trajectory_size];
-    trajectories = new uint32_t**[number_trajectories];
-    for(uint32_t i = 0; i < number_trajectories; i++){
-      trajectories[i] = new uint32_t*[number_timesteps];
-      for(uint32_t j = 0; j < number_timesteps; j++){
+    unsigned int trajectory_size = number_timesteps * (model -> number_species);
+    trajectories_1D = new unsigned int[number_trajectories * trajectory_size];
+    trajectories = new unsigned int**[number_trajectories];
+    for(unsigned int i = 0; i < number_trajectories; i++){
+      trajectories[i] = new unsigned int*[number_timesteps];
+      for(unsigned int j = 0; j < number_timesteps; j++){
 	trajectories[i][j] = &(trajectories_1D[i * trajectory_size + j *  (model -> number_species)]);
       }
     }    
@@ -65,7 +64,7 @@ namespace Gillespy{
   Simulation :: ~Simulation(){
     delete timeline;
     delete trajectories_1D;
-    for(uint32_t i = 0; i < number_trajectories; i++){
+    for(unsigned int i = 0; i < number_trajectories; i++){
       delete trajectories[i];
     }
     delete trajectories;
@@ -73,10 +72,10 @@ namespace Gillespy{
 
   
   std :: ostream& operator<<(std :: ostream& os, const Simulation& simulation){
-    for(uint32_t i = 0; i < simulation.number_timesteps; i++){
+    for(unsigned int i = 0; i < simulation.number_timesteps; i++){
       os << simulation.timeline[i] << " ";
-      for(uint32_t trajectory = 0; trajectory < simulation.number_trajectories; trajectory++){
-	for(uint32_t j = 0; j < simulation.model -> number_species; j++){
+      for(unsigned int trajectory = 0; trajectory < simulation.number_trajectories; trajectory++){
+	for(unsigned int j = 0; j < simulation.model -> number_species; j++){
 	  os << simulation.trajectories[trajectory][i][j] <<  " ";
 	}
       }
@@ -88,15 +87,15 @@ namespace Gillespy{
   void Simulation :: output_results_buffer(std :: ostream& os){
     double temp;
     unsigned char* temp_byte = reinterpret_cast<unsigned char*>(&temp);
-    for(uint32_t i = 0; i < number_timesteps; i++){
+    for(unsigned int i = 0; i < number_timesteps; i++){
       temp = timeline[i];
-      for(uint32_t byte_i = 0; byte_i < sizeof(double); byte_i++){
+      for(unsigned int byte_i = 0; byte_i < sizeof(double); byte_i++){
 	os << temp_byte[byte_i];
       }
-      for(uint32_t trajectory = 0; trajectory < number_trajectories; trajectory++){
-	for(uint32_t j = 0; j < model -> number_species; j++){
+      for(unsigned int trajectory = 0; trajectory < number_trajectories; trajectory++){
+	for(unsigned int j = 0; j < model -> number_species; j++){
 	  temp = trajectories[trajectory][i][j];
-	  for(uint32_t byte_i = 0; byte_i < sizeof(double); byte_i++){
+	  for(unsigned int byte_i = 0; byte_i < sizeof(double); byte_i++){
 	    os << temp_byte[byte_i];
 	  }
 	}

--- a/gillespy2/solvers/cpp/c_base/model.cpp
+++ b/gillespy2/solvers/cpp/c_base/model.cpp
@@ -1,38 +1,39 @@
 #include "model.h"
+#include <cstdint>
 
 namespace Gillespy{
   
-  Model :: Model(std :: vector<std :: string> species_names, std :: vector<uint> species_populations, std :: vector<std :: string> reaction_names):
+  Model :: Model(std :: vector<std :: string> species_names, std :: vector<uint32_t> species_populations, std :: vector<std :: string> reaction_names):
     number_species(species_names.size()),
     number_reactions(reaction_names.size())
   {
     species = std :: make_unique<Species[]>(number_species);
-    for(uint i = 0; i < number_species; i++){
+    for(uint32_t i = 0; i < number_species; i++){
       species[i].id = i;
       species[i].initial_population = species_populations[i];
       species[i].name = species_names[i];
     }
     reactions = std :: make_unique<Reaction[]>(number_reactions);
-    for(uint i = 0; i < number_reactions; i++){
+    for(uint32_t i = 0; i < number_reactions; i++){
       reactions[i].name = reaction_names[i];
       reactions[i].species_change = std :: make_unique<int[]>(number_species);
-      for(uint j = 0; j < number_species; j++){
+      for(uint32_t j = 0; j < number_species; j++){
 	reactions[i].species_change[j] = 0;	
       }
-      reactions[i].affected_reactions = std :: vector<uint>();
+      reactions[i].affected_reactions = std :: vector<uint32_t>();
     }
   }
 
   void Model :: update_affected_reactions(){
     //Clear affected_reactions for each reaction
-    for(uint i = 0; i < number_reactions; i++){
+    for(uint32_t i = 0; i < number_reactions; i++){
       reactions[i].affected_reactions.clear();
     }   
     //Check all reactions for common species changes -> affected reactions
-    for(uint r1 = 0; r1 < number_reactions; r1++){
+    for(uint32_t r1 = 0; r1 < number_reactions; r1++){
       reactions[r1].affected_reactions.push_back(r1);
-      for(uint r2 = r1 + 1; r2 < number_reactions; r2++){
-	for(uint s = 0; s < number_species; s++){
+      for(uint32_t r2 = r1 + 1; r2 < number_reactions; r2++){
+	for(uint32_t s = 0; s < number_species; s++){
 	  if(reactions[r1].species_change[s] != 0 and reactions[r2].species_change[s] != 0){
 	    reactions[r1].affected_reactions.push_back(r2);
 	    reactions[r2].affected_reactions.push_back(r1);
@@ -43,18 +44,18 @@ namespace Gillespy{
   }
 
 
-  Simulation :: Simulation(Model* model, uint number_trajectories, uint number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed) : model(model), end_time(end_time), random_seed(random_seed), number_timesteps(number_timesteps), number_trajectories(number_trajectories), propensity_function(propensity_function){
+  Simulation :: Simulation(Model* model, uint32_t number_trajectories, uint32_t number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed) : model(model), end_time(end_time), random_seed(random_seed), number_timesteps(number_timesteps), number_trajectories(number_trajectories), propensity_function(propensity_function){
     timeline = new double[number_timesteps];
     double timestep_size = end_time/(number_timesteps-1);
-    for(uint i = 0; i < number_timesteps; i++){
+    for(uint32_t i = 0; i < number_timesteps; i++){
       timeline[i] = timestep_size * i;
     }
-    uint trajectory_size = number_timesteps * (model -> number_species);
-    trajectories_1D = new uint[number_trajectories * trajectory_size];
-    trajectories = new uint**[number_trajectories];
-    for(uint i = 0; i < number_trajectories; i++){
-      trajectories[i] = new uint*[number_timesteps];
-      for(uint j = 0; j < number_timesteps; j++){
+    uint32_t trajectory_size = number_timesteps * (model -> number_species);
+    trajectories_1D = new uint32_t[number_trajectories * trajectory_size];
+    trajectories = new uint32_t**[number_trajectories];
+    for(uint32_t i = 0; i < number_trajectories; i++){
+      trajectories[i] = new uint32_t*[number_timesteps];
+      for(uint32_t j = 0; j < number_timesteps; j++){
 	trajectories[i][j] = &(trajectories_1D[i * trajectory_size + j *  (model -> number_species)]);
       }
     }    
@@ -64,7 +65,7 @@ namespace Gillespy{
   Simulation :: ~Simulation(){
     delete timeline;
     delete trajectories_1D;
-    for(uint i = 0; i < number_trajectories; i++){
+    for(uint32_t i = 0; i < number_trajectories; i++){
       delete trajectories[i];
     }
     delete trajectories;
@@ -72,10 +73,10 @@ namespace Gillespy{
 
   
   std :: ostream& operator<<(std :: ostream& os, const Simulation& simulation){
-    for(uint i = 0; i < simulation.number_timesteps; i++){
+    for(uint32_t i = 0; i < simulation.number_timesteps; i++){
       os << simulation.timeline[i] << " ";
-      for(uint trajectory = 0; trajectory < simulation.number_trajectories; trajectory++){
-	for(uint j = 0; j < simulation.model -> number_species; j++){
+      for(uint32_t trajectory = 0; trajectory < simulation.number_trajectories; trajectory++){
+	for(uint32_t j = 0; j < simulation.model -> number_species; j++){
 	  os << simulation.trajectories[trajectory][i][j] <<  " ";
 	}
       }
@@ -87,15 +88,15 @@ namespace Gillespy{
   void Simulation :: output_results_buffer(std :: ostream& os){
     double temp;
     unsigned char* temp_byte = reinterpret_cast<unsigned char*>(&temp);
-    for(uint i = 0; i < number_timesteps; i++){
+    for(uint32_t i = 0; i < number_timesteps; i++){
       temp = timeline[i];
-      for(uint byte_i = 0; byte_i < sizeof(double); byte_i++){
+      for(uint32_t byte_i = 0; byte_i < sizeof(double); byte_i++){
 	os << temp_byte[byte_i];
       }
-      for(uint trajectory = 0; trajectory < number_trajectories; trajectory++){
-	for(uint j = 0; j < model -> number_species; j++){
+      for(uint32_t trajectory = 0; trajectory < number_trajectories; trajectory++){
+	for(uint32_t j = 0; j < model -> number_species; j++){
 	  temp = trajectories[trajectory][i][j];
-	  for(uint byte_i = 0; byte_i < sizeof(double); byte_i++){
+	  for(uint32_t byte_i = 0; byte_i < sizeof(double); byte_i++){
 	    os << temp_byte[byte_i];
 	  }
 	}

--- a/gillespy2/solvers/cpp/c_base/model.h
+++ b/gillespy2/solvers/cpp/c_base/model.h
@@ -4,37 +4,38 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include <cstdint>
 
 namespace Gillespy{
 
   //Represents info for a chemical reactant/product
   struct Species{
-    uint id; //useful for index id in arrays
+    uint32_t id; //useful for index id in arrays
     std :: string name;
-    uint initial_population;
+    uint32_t initial_population;
   };
   
   struct Reaction{
-    uint id; //useful for propensity function id associated
+    uint32_t id; //useful for propensity function id associated
     std :: string name;
     std :: unique_ptr<int[]> species_change; //list of changes to species with this reaction firing
-    std :: vector<uint> affected_reactions; //list of which reactions have propensities that would change with this reaction firing 
+    std :: vector<uint32_t> affected_reactions; //list of which reactions have propensities that would change with this reaction firing 
   };
   
   //Represents a model of reactions and species
   struct Model{
-    uint number_species;
+    uint32_t number_species;
     std :: unique_ptr<Species[]> species;
-    uint number_reactions;
+    uint32_t number_reactions;
     std :: unique_ptr<Reaction[]> reactions;
-    Model(std :: vector<std :: string> species_names, std :: vector<uint> species_populations, std :: vector<std :: string> reaction_names);
+    Model(std :: vector<std :: string> species_names, std :: vector<uint32_t> species_populations, std :: vector<std :: string> reaction_names);
     void update_affected_reactions();
   };
   
   //Interface class to represent container for propensity functions
   class IPropensityFunction{
   public:
-    virtual double evaluate(uint reaction_number, uint* state) = 0;
+    virtual double evaluate(uint32_t reaction_number, uint32_t* state) = 0;
     virtual ~IPropensityFunction() {}; 
   };
 
@@ -45,12 +46,12 @@ namespace Gillespy{
     double* timeline;
     double end_time;
     int random_seed;
-    uint number_timesteps;
-    uint number_trajectories;
-    uint* trajectories_1D;
-    uint*** trajectories;
+    uint32_t number_timesteps;
+    uint32_t number_trajectories;
+    uint32_t* trajectories_1D;
+    uint32_t*** trajectories;
     IPropensityFunction *propensity_function;
-    Simulation(Model* model, uint number_trajectories, uint number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed);
+    Simulation(Model* model, uint32_t number_trajectories, uint32_t number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed);
     ~Simulation();
     friend std :: ostream& operator<<(std :: ostream& os, const Simulation& simulation);
     void output_results_buffer(std :: ostream& os);

--- a/gillespy2/solvers/cpp/c_base/model.h
+++ b/gillespy2/solvers/cpp/c_base/model.h
@@ -4,38 +4,37 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <cstdint>
 
 namespace Gillespy{
 
   //Represents info for a chemical reactant/product
   struct Species{
-    uint32_t id; //useful for index id in arrays
+    unsigned int id; //useful for index id in arrays
     std :: string name;
-    uint32_t initial_population;
+    unsigned int initial_population;
   };
   
   struct Reaction{
-    uint32_t id; //useful for propensity function id associated
+    unsigned int id; //useful for propensity function id associated
     std :: string name;
     std :: unique_ptr<int[]> species_change; //list of changes to species with this reaction firing
-    std :: vector<uint32_t> affected_reactions; //list of which reactions have propensities that would change with this reaction firing 
+    std :: vector<unsigned int> affected_reactions; //list of which reactions have propensities that would change with this reaction firing 
   };
   
   //Represents a model of reactions and species
   struct Model{
-    uint32_t number_species;
+    unsigned int number_species;
     std :: unique_ptr<Species[]> species;
-    uint32_t number_reactions;
+    unsigned int number_reactions;
     std :: unique_ptr<Reaction[]> reactions;
-    Model(std :: vector<std :: string> species_names, std :: vector<uint32_t> species_populations, std :: vector<std :: string> reaction_names);
+    Model(std :: vector<std :: string> species_names, std :: vector<unsigned int> species_populations, std :: vector<std :: string> reaction_names);
     void update_affected_reactions();
   };
   
   //Interface class to represent container for propensity functions
   class IPropensityFunction{
   public:
-    virtual double evaluate(uint32_t reaction_number, uint32_t* state) = 0;
+    virtual double evaluate(unsigned int reaction_number, unsigned int* state) = 0;
     virtual ~IPropensityFunction() {}; 
   };
 
@@ -46,12 +45,12 @@ namespace Gillespy{
     double* timeline;
     double end_time;
     int random_seed;
-    uint32_t number_timesteps;
-    uint32_t number_trajectories;
-    uint32_t* trajectories_1D;
-    uint32_t*** trajectories;
+    unsigned int number_timesteps;
+    unsigned int number_trajectories;
+    unsigned int* trajectories_1D;
+    unsigned int*** trajectories;
     IPropensityFunction *propensity_function;
-    Simulation(Model* model, uint32_t number_trajectories, uint32_t number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed);
+    Simulation(Model* model, unsigned int number_trajectories, unsigned int number_timesteps, double end_time, IPropensityFunction* propensity_function, int random_seed);
     ~Simulation();
     friend std :: ostream& operator<<(std :: ostream& os, const Simulation& simulation);
     void output_results_buffer(std :: ostream& os);

--- a/gillespy2/solvers/cpp/c_base/ssa.cpp
+++ b/gillespy2/solvers/cpp/c_base/ssa.cpp
@@ -2,27 +2,26 @@
 #include <random>//Included for mt19937 random number generator
 #include <cmath>//Included for natural logarithm
 #include <string.h>//Included for memcpy only
-#include <cstdint>
 
 namespace Gillespy{
   void ssa_direct(Simulation* simulation){
     if(simulation){
       std :: mt19937_64 rng(simulation -> random_seed);
       //Number of bytes for copying states
-      uint32_t state_size = sizeof(int)*((simulation -> model) -> number_species);
+      unsigned int state_size = sizeof(int)*((simulation -> model) -> number_species);
       //Current state
-      uint32_t* current_state = new uint32_t[(simulation -> model) -> number_species];
+      unsigned int* current_state = new unsigned int[(simulation -> model) -> number_species];
       //Calculated propensity values for current state
       double* propensity_values = new double[(simulation -> model) -> number_reactions];
       
       //copy initial state for each trajectory
-      for(uint32_t species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
+      for(unsigned int species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
 	simulation -> trajectories[0][0][species_number] = (simulation -> model) -> species[species_number].initial_population;
       }
       //Simulate for each trajectory
-      for(uint32_t trajectory_number = 0; trajectory_number < simulation -> number_trajectories; trajectory_number++){
+      for(unsigned int trajectory_number = 0; trajectory_number < simulation -> number_trajectories; trajectory_number++){
 	//Get simpler reference to memory space for this trajectory
-	uint32_t** trajectory = simulation -> trajectories[trajectory_number];
+	unsigned int** trajectory = simulation -> trajectories[trajectory_number];
 	//Copy initial state as needed
 	if(trajectory_number > 0){
 	  memcpy(trajectory[0], simulation -> trajectories[0][0], state_size);
@@ -30,22 +29,22 @@ namespace Gillespy{
 	//Set up current state from initial state
 	memcpy(current_state, trajectory[0], state_size);
 	double current_time = 0;
-	uint32_t entry_count = 1;
+	unsigned int entry_count = 1;
 	//calculate initial propensities
-	for(uint32_t reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
+	for(unsigned int reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
 	  propensity_values[reaction_number] = (simulation -> propensity_function) -> evaluate(reaction_number, current_state);
 	}
 	double propensity_sum;
 	while(current_time < (simulation -> end_time)){
 	  //Sum propensities
 	  propensity_sum = 0;
-	  for(uint32_t reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
+	  for(unsigned int reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
 	    propensity_sum += propensity_values[reaction_number];
 	  }
 	  //No more reactions
 	  if(propensity_sum <= 0){
 	    //Copy all of last changed state for rest of entries
-	    for(uint32_t i = entry_count; i < simulation -> number_timesteps; i++){
+	    for(unsigned int i = entry_count; i < simulation -> number_timesteps; i++){
 	      memcpy(trajectory[i], current_state, state_size);
 	    }
 	    //Quit simulating this trajectory
@@ -61,17 +60,17 @@ namespace Gillespy{
 	    entry_count++;
 	  }
 	  
-	  for(uint32_t potential_reaction = 0; potential_reaction < ((simulation -> model) -> number_reactions); potential_reaction++){
+	  for(unsigned int potential_reaction = 0; potential_reaction < ((simulation -> model) -> number_reactions); potential_reaction++){
 	    cumulative_sum -= propensity_values[potential_reaction];
 	    //This reaction fired
 	    if (cumulative_sum <= 0 && propensity_values[potential_reaction] > 0){
 	      //Update current state
 	      Reaction& reaction = ((simulation -> model) -> reactions[potential_reaction]);
-	      for(uint32_t species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
+	      for(unsigned int species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
 		current_state[species_number] += reaction.species_change[species_number];
 	      }
 	      //Recalculate needed propensities
-	      for(uint32_t& affected_reaction : reaction.affected_reactions){
+	      for(unsigned int& affected_reaction : reaction.affected_reactions){
 	 	propensity_values[affected_reaction] =  (simulation -> propensity_function) -> evaluate(affected_reaction, current_state);
 	      }
 	      break;

--- a/gillespy2/solvers/cpp/c_base/ssa.cpp
+++ b/gillespy2/solvers/cpp/c_base/ssa.cpp
@@ -2,26 +2,27 @@
 #include <random>//Included for mt19937 random number generator
 #include <cmath>//Included for natural logarithm
 #include <string.h>//Included for memcpy only
+#include <cstdint>
 
 namespace Gillespy{
   void ssa_direct(Simulation* simulation){
     if(simulation){
       std :: mt19937_64 rng(simulation -> random_seed);
       //Number of bytes for copying states
-      uint state_size = sizeof(int)*((simulation -> model) -> number_species);
+      uint32_t state_size = sizeof(int)*((simulation -> model) -> number_species);
       //Current state
-      uint* current_state = new uint[(simulation -> model) -> number_species];
+      uint32_t* current_state = new uint32_t[(simulation -> model) -> number_species];
       //Calculated propensity values for current state
       double* propensity_values = new double[(simulation -> model) -> number_reactions];
       
       //copy initial state for each trajectory
-      for(uint species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
+      for(uint32_t species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
 	simulation -> trajectories[0][0][species_number] = (simulation -> model) -> species[species_number].initial_population;
       }
       //Simulate for each trajectory
-      for(uint trajectory_number = 0; trajectory_number < simulation -> number_trajectories; trajectory_number++){
+      for(uint32_t trajectory_number = 0; trajectory_number < simulation -> number_trajectories; trajectory_number++){
 	//Get simpler reference to memory space for this trajectory
-	uint** trajectory = simulation -> trajectories[trajectory_number];
+	uint32_t** trajectory = simulation -> trajectories[trajectory_number];
 	//Copy initial state as needed
 	if(trajectory_number > 0){
 	  memcpy(trajectory[0], simulation -> trajectories[0][0], state_size);
@@ -29,22 +30,22 @@ namespace Gillespy{
 	//Set up current state from initial state
 	memcpy(current_state, trajectory[0], state_size);
 	double current_time = 0;
-	uint entry_count = 1;
+	uint32_t entry_count = 1;
 	//calculate initial propensities
-	for(uint reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
+	for(uint32_t reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
 	  propensity_values[reaction_number] = (simulation -> propensity_function) -> evaluate(reaction_number, current_state);
 	}
 	double propensity_sum;
 	while(current_time < (simulation -> end_time)){
 	  //Sum propensities
 	  propensity_sum = 0;
-	  for(uint reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
+	  for(uint32_t reaction_number = 0; reaction_number < ((simulation -> model) -> number_reactions); reaction_number++){
 	    propensity_sum += propensity_values[reaction_number];
 	  }
 	  //No more reactions
 	  if(propensity_sum <= 0){
 	    //Copy all of last changed state for rest of entries
-	    for(uint i = entry_count; i < simulation -> number_timesteps; i++){
+	    for(uint32_t i = entry_count; i < simulation -> number_timesteps; i++){
 	      memcpy(trajectory[i], current_state, state_size);
 	    }
 	    //Quit simulating this trajectory
@@ -60,17 +61,17 @@ namespace Gillespy{
 	    entry_count++;
 	  }
 	  
-	  for(uint potential_reaction = 0; potential_reaction < ((simulation -> model) -> number_reactions); potential_reaction++){
+	  for(uint32_t potential_reaction = 0; potential_reaction < ((simulation -> model) -> number_reactions); potential_reaction++){
 	    cumulative_sum -= propensity_values[potential_reaction];
 	    //This reaction fired
 	    if (cumulative_sum <= 0 && propensity_values[potential_reaction] > 0){
 	      //Update current state
 	      Reaction& reaction = ((simulation -> model) -> reactions[potential_reaction]);
-	      for(uint species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
+	      for(uint32_t species_number = 0; species_number < ((simulation -> model) -> number_species); species_number++){
 		current_state[species_number] += reaction.species_change[species_number];
 	      }
 	      //Recalculate needed propensities
-	      for(uint& affected_reaction : reaction.affected_reactions){
+	      for(uint32_t& affected_reaction : reaction.affected_reactions){
 	 	propensity_values[affected_reaction] =  (simulation -> propensity_function) -> evaluate(affected_reaction, current_state);
 	      }
 	      break;

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -27,7 +27,7 @@ def write_constants(outfile, model, reactions, species, parameter_mappings):
         for i in range(len(species)-1):
             outfile.write('"{}", '.format(species[i]))
         outfile.write('"{}"'.format(species[-1]))
-        outfile.write("};\nuint populations[] = {")
+        outfile.write("};\nuint32_t populations[] = {")
         #Write initial populations.
         for i in range(len(species)-1):
             outfile.write('{}, '.format(model.listOfSpecies[species[i]].initial_value))

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -27,7 +27,7 @@ def write_constants(outfile, model, reactions, species, parameter_mappings):
         for i in range(len(species)-1):
             outfile.write('"{}", '.format(species[i]))
         outfile.write('"{}"'.format(species[-1]))
-        outfile.write("};\nuint32_t populations[] = {")
+        outfile.write("};\nunsigned int populations[] = {")
         #Write initial populations.
         for i in range(len(species)-1):
             outfile.write('{}, '.format(model.listOfSpecies[species[i]].initial_value))


### PR DESCRIPTION
Expanding `uint` to `unsigned int` increases compatibility with cross-platform C compilers, and fixes an issue (#21) we had where the SSACSolver wasn't working correctly on Windows 10.