### PR TITLE
Return base trajectory numpy array for unlabeled outputs instead of l…

### DIFF
--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -99,5 +99,5 @@ class NumPySSASolver(GillesPySolver):
                     data[species[i]] = trajectory[:, i+1]
                 simulation_data.append(data)
             else:
-                simulation_data.append(trajectory)
+                simulation_data = trajectory_base
         return simulation_data


### PR DESCRIPTION
Corrected a bug in which the NumPySSASolver would return a list of NumPy arrays instead of a single NumPy array when show_labels=False.