### PR TITLE
bugfix in StochMLDocument.to_model: Species references in Reactions

### DIFF
--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -1016,7 +1016,7 @@ class StochMLDocument():
                     try:
                         # The sref list should only contain one element if
                         # the XML file is valid.
-                        reaction.reactants[specname] = stoch
+                        reaction.reactants[sref] = stoch
                     except Exception as e:
                         StochMLImportError(e)
             except:
@@ -1032,7 +1032,7 @@ class StochMLDocument():
                     try:
                         # The sref list should only contain one element if
                         # the XML file is valid.
-                        reaction.products[specname] = stoch
+                        reaction.products[sref] = stoch
                     except Exception as e:
                         raise StochMLImportError(e)
             except:


### PR DESCRIPTION
Expected output from solver not seen when using NumPySSASolver for model read from xml file using gillespy2.StochMLDocument. To reproduce this problem:
- take any model and convert to xml using StochMLDocument
- read the xml using StochMLDocument, convert to model (.to_model('model_name'))
- run the model using NumPySSASolver, no errors raised but the output is not what you expect (all trajectories constant)

Solution:
- in the model (read from xml) observe: model.listOfReations[<some reaction>].products
  the species reference is a string and not an instance of Species, same apply for reactants
- bug was found in gillespy2.StochMLDocument.to_model() where 'sref' while setting Reactions was never used
- see commit

Thank you!
/Fredrik Wrede 