### PR TITLE
removed references to stoch_kit_home, profile, and debug in model.run

### DIFF
--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -449,8 +449,6 @@ class Model(object):
                     "argument 'solver' to run() must be a subclass of GillesPySolver")
         else:
             from gillespy2.solvers.auto import SSASolver
-            if debug:
-                print("Using Solver: {0}".format(SSASolver.name))
             return SSASolver.run(model=self, t=self.tspan[-1],
                                       increment=self.tspan[-1] - self.tspan[-2], seed=seed,
                                       number_of_trajectories=number_of_trajectories,

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -410,7 +410,7 @@ class Model(object):
         self.listOfReactions.clear()
 
     def run(self, number_of_trajectories=1, seed=None,
-            solver=None, stochkit_home=None, profile=False, debug=False, show_labels=True):
+            solver=None, show_labels=True):
         """
         Function calling simulation of the model. There are a number of
         parameters to be set here.
@@ -443,7 +443,6 @@ class Model(object):
                                   increment=self.tspan[-1] - self.tspan[-2],
                                   seed=seed,
                                   number_of_trajectories=number_of_trajectories,
-                                  stochkit_home=stochkit_home, profile=profile, debug=debug,
                                   show_labels=show_labels)
             else:
                 raise SimulationError(
@@ -455,7 +454,6 @@ class Model(object):
             return SSASolver.run(model=self, t=self.tspan[-1],
                                       increment=self.tspan[-1] - self.tspan[-2], seed=seed,
                                       number_of_trajectories=number_of_trajectories,
-                                      stochkit_home=stochkit_home, profile=profile, debug=debug,
                                       show_labels=show_labels)
 
 


### PR DESCRIPTION
Just a quick fix removing these kwargs from model.run(), if they are needed, they can be used with solver.run() for the relevant solvers.

fix for issue #103 