### PR TITLE
Order propensity formulas

### DIFF
--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -46,7 +46,59 @@ def import_SBML(filename, name=None, gillespy_model=None):
     return convert(filename, model_name=name, gillespy_model=gillespy_model)
 
 
-class Model(object):
+class SortableObject(object):
+    """Base class for GillesPy2 objects that are sortable."""
+
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__)
+                and ordered(self) == ordered(other))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __gt__(self, other):
+        return not __le__(self, other)
+
+    def __ge__(self, other):
+        return not __lt__(self, other)
+
+    def __lt__(self, other):
+        if hasattr(self, 'id') and hasattr(other, 'id'):
+            return self.id.lower() < other.id.lower()
+        elif hasattr(self, 'name') and hasattr(other, 'name'):
+            return self.name.lower() < other.name.lower()
+        else:
+            return repr(self) < repr(other)
+
+    def __le__(self, other):
+        if hasattr(self, 'id') and hasattr(other, 'id'):
+            return self.id.lower() <= other.id.lower()
+        elif hasattr(self, 'name') and hasattr(other, 'name'):
+            return self.name.lower() <= other.name.lower()
+        else:
+            return repr(self) <= repr(other)
+
+    def __cmp__(self, other):
+        if hasattr(self, 'id') and hasattr(other, 'id'):
+            return cmp(self.id.lower(), other.id.lower())
+        elif hasattr(self, 'name') and hasattr(other, 'name'):
+            return cmp(self.name.lower(), other.name.lower())
+        else:
+            return cmp(repr(self), repr(other))
+
+    def __hash__(self):
+        if hasattr(self, '_hash'):
+            return self._hash
+        if hasattr(self, 'id'):
+            self._hash = hash(self.id)
+        elif hasattr(self, 'name'):
+            self._hash = hash(self.name)
+        else:
+            self._hash = hash(self)
+        return self._hash
+
+
+class Model(SortableObject):
     # reserved names for model species/parameter names, volume, and operators.
     reserved_names = ['vol']
     special_characters = ['[', ']', '+', '-', '*', '/', '.', '^']
@@ -131,7 +183,7 @@ class Model(object):
         :return: the dictionary mapping user species names to their internal GillesPy notation.
         """
         species_name_mapping = OrderedDict([])
-        for i, name in enumerate(self.listOfSpecies.keys()):
+        for i, name in enumerate(sorted(self.listOfSpecies.keys())):
             species_name_mapping[name] = 'S[{}]'.format(i)
         return species_name_mapping
 
@@ -182,7 +234,7 @@ class Model(object):
                 raise problem
             self.listOfSpecies[obj.name] = obj
         elif isinstance(obj, list):
-            for S in obj:
+            for S in sorted(obj):
                 self.add_species(S)
         else:
             raise ModelError("Unexpected parameter for add_species. Parameter must be Species or list of Species.")
@@ -227,7 +279,7 @@ class Model(object):
         """
         parameter_name_mapping = OrderedDict()
         parameter_name_mapping['vol'] = 'V'
-        for i, name in enumerate(self.listOfParameters.keys()):
+        for i, name in enumerate(sorted(self.listOfParameters.keys())):
             if name not in parameter_name_mapping:
                 parameter_name_mapping[name] = 'P{}'.format(i)
         return parameter_name_mapping
@@ -263,8 +315,8 @@ class Model(object):
         obj : Parameter, or list of Parameters
             The parameter or list of parameters to be added to the model object.
         """
-        if isinstance(params,list): 
-            for p in params:
+        if isinstance(params,list):
+            for p in sorted(params):
                 self.add_parameter(p)
         else:
             if isinstance(params, Parameter):
@@ -346,7 +398,7 @@ class Model(object):
 
         # TODO, make sure that you cannot overwrite an existing reaction
         if isinstance(reactions,list):
-            for r in reactions:
+            for r in sorted(reactions):
                 self.add_reaction(r)
         elif isinstance(reactions,Reaction):
             reactions.verify()
@@ -372,7 +424,7 @@ class Model(object):
         # TODO, make sure that you cannot overwrite an existing reaction
         # param_type = type(reactions).__name__
         if isinstance(rate_rules, list):
-            for rr in rate_rules:
+            for rr in sorted(rate_rules):
                 self.add_rate_rule(rr)
         elif isinstance(rate_rules, RateRule):
             if rate_rules.species is None or not isinstance(rate_rules.species, Species): raise ModelError(
@@ -478,7 +530,8 @@ class Model(object):
         else:
             raise ValueError("number_of_trajectories must be non-negative and non-zero")
 
-class Species:
+
+class Species(SortableObject):
     """
     Chemical species. Can be added to Model object to interact with other
     species or time.
@@ -523,7 +576,7 @@ non-negative unless allow_negative_populations=True')
         return self.name
 
 
-class Parameter:
+class Parameter(SortableObject):
     """
     A parameter can be given as an expression (function) or directly
     as a value (scalar). If given an expression, it should be
@@ -603,7 +656,7 @@ class RateRule:
 
 
 
-class Reaction:
+class Reaction(SortableObject):
     """
     Models a single reaction. A reaction has its own dicts of species
     (reactants and products) and parameters. The reaction's propensity
@@ -712,7 +765,7 @@ class Reaction:
         # Users can still create such propensities if they really want to,
         # but should then use a custom propensity.
         total_stoch = 0
-        for r in self.reactants:
+        for r in sorted(self.reactants):
             total_stoch += self.reactants[r]
         if total_stoch > 2:
             raise ReactionError("Reaction: A mass-action reaction cannot involve more than two of one species or one "
@@ -723,7 +776,7 @@ class Reaction:
         ode_propensity_function = self.marate.name
 
         # There are only three ways to get 'total_stoch==2':
-        for r in self.reactants:
+        for r in sorted(self.reactants):
             # Case 1: 2X -> Y
             if self.reactants[r] == 2:
                 propensity_function = (propensity_function +
@@ -800,9 +853,9 @@ class Reaction:
         self.annotation = annotation
 
     def sanitized_propensity_function(self, species_mappings, parameter_mappings):
-        names = list(species_mappings.keys()) + list(parameter_mappings.keys())
-        names.sort(key=lambda name: -len(name))
-        replacements = [parameter_mappings[name] if name in parameter_mappings else species_mappings[name] for name in names]
+        names = sorted(list(species_mappings.keys()) + list(parameter_mappings.keys()))
+        replacements = [parameter_mappings[name] if name in parameter_mappings else species_mappings[name]
+                        for name in names]
         sanitized_propensity = self.propensity_function
         for id, name in enumerate(names):
             sanitized_propensity = sanitized_propensity.replace(name, "{"+str(id)+"}")

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -1,12 +1,15 @@
 import unittest, sys, os
 import argparse
-import pyximport
 
-pyximport.install()
+try:
+    import pyximport
+    pyximport.install()
+except Exception:
+    pass
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-m', '--mode', default='develop', choices=['develop', 'release'], help='Run tests in develop mode or release mode.')
-
+parser.add_argument('-m', '--mode', default='develop', choices=['develop', 'release'],
+                    help='Run tests in develop mode or release mode.')
 
 if __name__ == '__main__':
     args = parser.parse_args()
@@ -15,7 +18,7 @@ if __name__ == '__main__':
         sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 
-    # import test_cython_ssa_solver
+    import test_cython_ssa_solver
     import test_empty_model
     import test_model
     import test_ode_solver
@@ -26,7 +29,7 @@ if __name__ == '__main__':
     import test_all_solvers
 
     modules = [
-        # test_cython_ssa_solver,
+        test_cython_ssa_solver,
         test_empty_model,
         test_model,
         test_ode_solver,

--- a/test/test_all_solvers.py
+++ b/test/test_all_solvers.py
@@ -1,17 +1,26 @@
 import unittest
 import numpy as np
+
+import gillespy2
 from gillespy2.example_models import Example
+from gillespy2.core.results import EnsembleResults, Results
 from gillespy2.solvers.cpp.ssa_c_solver import SSACSolver
-from gillespy2.solvers.cython.cython_ssa_solver import CythonSSASolver
 from gillespy2.solvers.numpy.basic_ode_solver import BasicODESolver
 from gillespy2.solvers.numpy.ssa_solver import NumPySSASolver
 from gillespy2.solvers.numpy.basic_tau_leaping_solver import BasicTauLeapingSolver
 from gillespy2.solvers.numpy.basic_tau_hybrid_solver import BasicTauHybridSolver
-from gillespy2.core.results import EnsembleResults,Results
+
+from gillespy2.solvers.cython import can_use_cython
+if can_use_cython:
+    from gillespy2.solvers.cython.cython_ssa_solver import CythonSSASolver
+
 
 class TestAllSolvers(unittest.TestCase):
 
-    solvers = [SSACSolver, BasicODESolver, NumPySSASolver, BasicTauLeapingSolver, BasicTauHybridSolver, CythonSSASolver]
+    solvers = [SSACSolver, BasicODESolver, NumPySSASolver, BasicTauLeapingSolver, BasicTauHybridSolver]
+    if can_use_cython:
+        solvers.append(CythonSSASolver)
+
     model = Example()
     results = {}
     labeled_results = {}

--- a/test/test_cython_ssa_solver.py
+++ b/test/test_cython_ssa_solver.py
@@ -1,13 +1,17 @@
 import unittest
 from gillespy2.example_models import Example
-from gillespy2.solvers.cython.cython_ssa_solver import CythonSSASolver
+
+from gillespy2.solvers.cython import can_use_cython
+if can_use_cython:
+    from gillespy2.solvers.cython.cython_ssa_solver import CythonSSASolver
 
 
 class TestCythonSSASolver(unittest.TestCase):
 
     def test_run_example(self):
-        model = Example()
-        results = model.run(solver=CythonSSASolver)
+        if can_use_cython:
+            model = Example()
+            results = model.run(solver=CythonSSASolver)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix inconsistent propensity formula orderings

When I ran the unit tests, there was a failure in `test_ode_propensity` in `test/test_mode.py`. The error was:

```
FAIL: test_ode_propensity (test_model.TestModel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mhucka/project-files/stochss/repos/GillesPy2/test/test_model.py", line 151, in test_ode_propensity
    self.assertEqual(model.listOfReactions['r3'].ode_propensity_function, 'rate*A*B')
AssertionError: 'rate*B*A' != 'rate*A*B'
- rate*B*A
?       --
+ rate*A*B
?      ++
```

<br>The problem was due to the way that propensity formulas were sorted in `Reaction.sanitized_propensity_function(...)`. The method sorted by the _length_ of the names of the variables in the formula, but that approach will not yield a consistent ordering across different platforms when the names are of the same length.

My solution was to implement proper Python object ordering for `Species`, `Parameter` and a couple of other object classes. The implementation uses a simple base class, `SortableObject`, that defines Python methods for things like `__eq__(...)`, `__le__(...)`, etc. The class definitions for `Model`, `Species` and other things then use that base class, which makes those object instances comparable using normal Python functions like `sorted(...)`.  From there, it was simple to change `Reaction.sanitized_propensity_function(...)` to sort the variables in the propensity formula in a consistent way based on alphabetic sort.

For good measure, I looked for other places in the code that used `for` loops to iterate over objects and append things to lists, and wrapped the lists with `sorted(...)`. I don't know for sure whether those were actually necessary, but it seemed safer, to ensure that they were more likely to lead to consistent behavior.