### PR TITLE
Fix timeline calculation

### DIFF
--- a/gillespy2/__version__.py
+++ b/gillespy2/__version__.py
@@ -5,7 +5,7 @@
 # @website https://github.com/GillesPy2/GillesPy2
 # =============================================================================
 
-__version__      = '1.2'
+__version__      = '1.2.1'
 __title__        = 'GillesPy2'
 __description__  = 'Python interface for Gillespie-style biochemical simulations'
 __url__          = 'https://github.com/GillesPy2/GillesPy2'

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -168,7 +168,7 @@ class SSACSolver(GillesPySolver):
                 log.warning('Unsupported keyword argument to {0} solver: {1}'.format(self.name, key))
         if self.compiled:
             self.simulation_data = None
-            number_timesteps = int(t//increment + 1)                    
+            number_timesteps = round(t/increment + 1)
             # Execute simulation.
             args = [os.path.join(self.output_directory, 'UserSimulation'), '-trajectories', str(number_of_trajectories), '-timesteps', str(number_timesteps), '-end', str(t)]
             if seed is not None:

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -168,7 +168,7 @@ class SSACSolver(GillesPySolver):
                 log.warning('Unsupported keyword argument to {0} solver: {1}'.format(self.name, key))
         if self.compiled:
             self.simulation_data = None
-            number_timesteps = round(t/increment + 1)
+            number_timesteps = int(round(t/increment + 1))
             # Execute simulation.
             args = [os.path.join(self.output_directory, 'UserSimulation'), '-trajectories', str(number_of_trajectories), '-timesteps', str(number_timesteps), '-end', str(t)]
             if seed is not None:

--- a/gillespy2/solvers/numpy/basic_ode_solver.py
+++ b/gillespy2/solvers/numpy/basic_ode_solver.py
@@ -76,7 +76,7 @@ class BasicODESolver(GillesPySolver):
         number_species = len(species)
 
         # create numpy array for timeline
-        timeline = np.linspace(0, t, (t // increment + 1))
+        timeline = np.linspace(0, t, round(t / increment + 1))
 
         # create numpy matrix to mark all state data of time and species
         trajectory_base = np.empty((number_of_trajectories, timeline.size, number_species + 1))

--- a/gillespy2/solvers/numpy/basic_tau_hybrid_solver.py
+++ b/gillespy2/solvers/numpy/basic_tau_hybrid_solver.py
@@ -295,7 +295,7 @@ class BasicTauHybridSolver(GillesPySolver):
         number_species = len(species)
 
         # create numpy array for timeline
-        timeline = np.linspace(0, t, (t // increment + 1))
+        timeline = np.linspace(0, t, round(t / increment + 1))
 
         # create numpy matrix to mark all state data of time and species
         trajectory_base = np.empty((number_of_trajectories, timeline.size, number_species + 1))

--- a/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
+++ b/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
@@ -110,7 +110,7 @@ class BasicTauLeapingSolver(GillesPySolver):
                 raise ModelError('seed must be a positive integer')
 
         # create numpy array for timeline
-        timeline = np.linspace(0, t, (t // increment + 1))
+        timeline = np.linspace(0, t, round(t / increment + 1))
 
         # create numpy matrix to mark all state data of time and species
         trajectory_base = np.empty((number_of_trajectories, timeline.size, number_species + 1))

--- a/gillespy2/solvers/stochkit/stochkit_solvers.py
+++ b/gillespy2/solvers/stochkit/stochkit_solvers.py
@@ -91,7 +91,7 @@ class StochKitBaseSolver(GillesPySolver):
 
         if increment is None:
             increment = t / 20.0
-        num_output_points = t // increment
+        num_output_points = round(t / increment)
 
         # Assemble the argument list
         args = '--model {0} --out-dir {1} -t {2} -i {3}'.format(outfile, out_dir, t, int(num_output_points))


### PR DESCRIPTION
The use of floor division in calculating the number of timesteps can result in off-by-1 errors compared to the expected number of timesteps. Using `round()` solves this, at least in my testing.