### PR TITLE
Fix for issue #256

### DIFF
--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -829,7 +829,8 @@ class Reaction(SortableObject):
             total_stoch += self.reactants[r]
         if total_stoch > 2:
             raise ReactionError("Reaction: A mass-action reaction cannot involve more than two of one species or one "
-                                "of two species.")
+                                "of two species. "
+                                "To declare a custom propensity, replace 'rate' with 'propensity_function'.")
         # Case EmptySet -> Y
 
         propensity_function = self.marate.name


### PR DESCRIPTION
- Change wording for ReactionError referenced in #256 

"Reaction: A mass-action reaction cannot involve more than two of one species or one
 of two species."

 to:

 "Reaction: A mass-action reaction cannot involve more than two of one species or one
 of two species. To declare a custom propensity, replace 'rate' with 'propensity_function'."