### PR TITLE
PyPi automatic deployment via Travis CI - master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,14 @@ install:
           - pip3 install cython
 script:
           python test/run_tests.py -m release
-
+deploy:
+  # API token stored in env var PYPI_PASSWORD on Travis CI
+  provider: pypi
+  distributions: sdist bdist_wheel
+  edge: true # opt in to dpl v2
+  user: __token__
+  on:
+    repo: GillesPy2/GillesPy2
+    branch: master
+    tags: true
+    


### PR DESCRIPTION
This pull request enables configuration changes to automatically deploy releases to PyPi under the condition the release is tagged on GitHub. Please ensure there is a PyPI API token stored in an environment variable named `PYPI_PASSWORD` on Travis CI. Additionally, when using this feature for the first time, please monitor the Travis CI build log under section `Run deployment` to ensure authentication is successful. Please see https://docs.travis-ci.com/user/deployment-v2/providers/pypi/ for additional information and settings.