### PR TITLE
Fix matplotlib.pyplot.plot() y axis scaling

### DIFF
--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -273,7 +273,6 @@ class Results(UserList):
                 trajectory_list.append(self.data[index])
         else:
             trajectory_list = self.data
-
         if title is None:
             title=self._validate_title()
 
@@ -312,8 +311,7 @@ class Results(UserList):
 
             if show_legend:
                 plt.legend(loc='best')
-            plt.plot([0], [11])
-
+            plt.plot()
             if isinstance(save_png, str):
                 plt.savefig(save_png)
 


### PR DESCRIPTION
- change plt.plot([0],[1]) to plt.plot(). matplotlib.pyplot.plot()  scales x and y axis data automatically, no need to specify anything. Data where all species are smaller than 1 will now plot properly.