### PR TITLE
Deprecate show_labels == False

### DIFF
--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -946,8 +946,6 @@ non-negative unless allow_negative_populations=True')
         :param num: Integer to set initial species population
         :raises SpeciesError: If num is non-negative or a decimal number
         """
-        print(num)
-        print(self.mode)
         if isinstance(num, float) and (self.mode != 'dynamic' or self.mode != 'continuous'):
             raise SpeciesError("Mode set to discrete, species must be an integer number.")
         if num < 0 and self.allow_negative_populations == False:

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -845,10 +845,12 @@ class Model(SortableObject):
             results_list = []
             for i in range(0, len(solver_results)):
                 temp = Trajectory(data=solver_results[i], model=self, solver_name=solver.name, rc=rc)
-                if not show_labels:
-                    temp = temp.to_array()
                 results_list.append(temp)
-            return Results(results_list)
+
+            results = Results(results_list)
+            if show_labels == False:
+                results = results.to_array()
+            return results
 
         else:
             raise ValueError("number_of_trajectories must be non-negative and non-zero")

--- a/gillespy2/core/gillespy2.py
+++ b/gillespy2/core/gillespy2.py
@@ -15,6 +15,7 @@ from gillespy2.core.events import *
 from gillespy2.core.gillespySolver import GillesPySolver
 from gillespy2.core.gillespyError import *
 
+
 try:
     import lxml.etree as eTree
 
@@ -795,7 +796,7 @@ class Model(SortableObject):
             return SSASolver
 
 
-    def run(self, solver=None, timeout=0, **solver_args):
+    def run(self, solver=None, timeout=0, show_labels=True, **solver_args):
         """
         Function calling simulation of the model. There are a number of
         parameters to be set here.
@@ -818,6 +819,9 @@ class Model(SortableObject):
         solver_args :
             solver-specific arguments to be passed to solver.run()
         """
+        if not show_labels:
+            from gillespy2.core import log
+            log.warning('show_labels = False is deprecated. Future releases of GillesPy2 may not support this feature.')
 
         if solver is not None:
             try:
@@ -837,16 +841,13 @@ class Model(SortableObject):
         if hasattr(solver_results[0], 'shape'):
             return solver_results
 
-        if len(solver_results) == 1:
-            results_list = [Trajectory(data=solver_results[0], model=self,
-                                       solver_name=solver.name, rc=rc)]
-            return Results(results_list)
-
-        if len(solver_results) > 1:
+        if len(solver_results) > 0:
             results_list = []
             for i in range(0, len(solver_results)):
-                results_list.append(Trajectory(data=solver_results[i], model=self, solver_name=solver.name,
-                                               rc=rc))
+                temp = Trajectory(data=solver_results[i], model=self, solver_name=solver.name, rc=rc)
+                if not show_labels:
+                    temp = temp.to_array()
+                results_list.append(temp)
             return Results(results_list)
 
         else:

--- a/gillespy2/core/gillespySolver.py
+++ b/gillespy2/core/gillespySolver.py
@@ -28,7 +28,7 @@ class GillesPySolver:
         Use names of species as index of result object rather than position numbers.
     """
     def run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None,
-            debug=False, profile=False, show_labels=False, **kwargs):
+            debug=False, profile=False, show_labels=None, **kwargs):
         """ 
         Call out and run the solver. Collect the results.
         """

--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -114,16 +114,6 @@ class Trajectory(UserDict):
             return self.__class__.__missing__(self, key)
         raise KeyError(key)
 
-    def to_array(self):
-        import numpy as np
-        size1 = len(self.data['time'])
-        size2 = len(self.data)
-        newArray = np.zeros((size1, size2))
-
-        for i, key in enumerate(self.data):
-            newArray[:, i] = self.data[key]
-        return newArray
-
 class Results(UserList):
     """ List of Trajectory objects created by a gillespy2 solver, extends the UserList object.
 
@@ -207,6 +197,19 @@ class Results(UserList):
             title_solver = 'Multiple Solvers'
         title = (title_model + " - " + title_solver)
         return title
+
+    def to_array(self):
+        import numpy as np
+        results = []
+        size1 = len(self.data[0]['time'])
+        size2 = len(self.data[0])
+        newArray = np.zeros((size1, size2))
+
+        for trajectory in range(0,len(self.data)):
+            for i, key in enumerate(self.data[trajectory]):
+                newArray[:, i] = self.data[trajectory][key]
+            results.append(newArray)
+        return results
 
     def to_csv(self, path=None, nametag=None, stamp=None):
         """ outputs the Results to one or more .csv files in a new directory.

--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -100,7 +100,7 @@ class Trajectory(UserDict):
         self.model = model
         self.solver_name = solver_name
         self.rc = rc
-        
+
         status_list = {0: 'Success', 33: 'Timed Out'}
         self.status = status_list[rc]
 
@@ -114,6 +114,15 @@ class Trajectory(UserDict):
             return self.__class__.__missing__(self, key)
         raise KeyError(key)
 
+    def to_array(self):
+        import numpy as np
+        size1 = len(self.data['time'])
+        size2 = len(self.data)
+        newArray = np.zeros((size1, size2))
+
+        for i, key in enumerate(self.data):
+            newArray[:, i] = self.data[key]
+        return newArray
 
 class Results(UserList):
     """ List of Trajectory objects created by a gillespy2 solver, extends the UserList object.

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -165,11 +165,10 @@ class SSACSolver(GillesPySolver):
         """
         :return: Tuple of strings, denoting all keyword argument for this solvers run() method.
         """
-        return ('model', 't', 'number_of_trajectories', 'timeout', 'increment', 'seed', 'debug', 'profile',
-                'show_labels')
+        return ('model', 't', 'number_of_trajectories', 'timeout', 'increment', 'seed', 'debug', 'profile')
 
     def run(self=None, model=None, t=20, number_of_trajectories=1, timeout=0,
-            increment=0.05, seed=None, debug=False, profile=False, show_labels=True, **kwargs):
+            increment=0.05, seed=None, debug=False, profile=False, **kwargs):
 
         if self is None or self.model is None:
             self = SSACSolver(model)
@@ -225,18 +224,19 @@ class SSACSolver(GillesPySolver):
  
             # Parse/return results.
             if return_code in [0, 33]:
-                trajectory_base = _parse_binary_output(stdout, number_of_trajectories, number_timesteps, len(self.species))
-                # Format results
-                if show_labels:
-                    self.simulation_data = []
-                    for trajectory in range(number_of_trajectories):
-                        data = {'time': trajectory_base[trajectory, :, 0]}
-                        for i in range(len(self.species)):
-                            data[self.species[i]] = trajectory_base[trajectory, :, i+1]
-                        self.simulation_data.append(data)
-                else:
-                    self.simulation_data = trajectory_base
+                trajectory_base = _parse_binary_output(stdout, number_of_trajectories, number_timesteps,
+                                                        len(self.species))
+
+                #Format results
+                self.simulation_data = []
+                for trajectory in range(number_of_trajectories):
+                    data = {'time': trajectory_base[trajectory, :, 0]}
+                    for i in range(len(self.species)):
+                        data[self.species[i]] = trajectory_base[trajectory, :, i+1]
+                    self.simulation_data.append(data)
             else:
-                raise gillespyError.ExecutionError("Error encountered while running simulation C++ file:\nReturn code: {0}.\nError:\n{1}\n".format(simulation.returncode, simulation.stderr))
+                raise gillespyError.ExecutionError("Error encountered while running simulation C++ file:"
+                                                   "\nReturn code: {0}.\nError:\n{1}\n".format(simulation.returncode,
+                                                                                               simulation.stderr))
         return self.simulation_data, return_code
 

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -173,15 +173,14 @@ class VariableSSACSolver(GillesPySolver):
         """
         :return: Tuple of strings, denoting all keyword argument for this solvers run() method.
         """
-        return ('model', 't', 'number_of_trajectories', 'timeout', 'increment', 'seed', 'debug', 'profile',
-                'show_labels', 'variables')
+        return ('model', 't', 'number_of_trajectories', 'timeout', 'increment', 'seed', 'debug', 'profile', 'variables')
 
     def run(self=None, model=None, t=20, number_of_trajectories=1, timeout=0,
-            increment=0.05, seed=None, debug=False, profile=False, show_labels=True, 
-            variables={}, **kwargs):
+            increment=0.05, seed=None, debug=False, profile=False, variables={}, **kwargs):
 
         if self is None or self.model is None:
             self = VariableSSACSolver(model)
+
         if len(kwargs) > 0:
             for key in kwargs:
                 log.warning('Unsupported keyword argument to {0} solver: {1}'.format(self.name, key))
@@ -275,18 +274,20 @@ is not a valid variable.  Variables must be model species or parameters.'.format
  
             # Parse/return results.
             if return_code in [0, 33]:
-                trajectory_base = _parse_binary_output(stdout, number_of_trajectories, number_timesteps, len(self.species))
+                trajectory_base = _parse_binary_output(stdout, number_of_trajectories, number_timesteps,
+                                                       len(self.species))
+
                 # Format results
-                if show_labels:
-                    self.simulation_data = []
-                    for trajectory in range(number_of_trajectories):
-                        data = {'time': trajectory_base[trajectory, :, 0]}
-                        for i in range(len(self.species)):
-                            data[self.species[i]] = trajectory_base[trajectory, :, i+1]
-                        self.simulation_data.append(data)
-                else:
-                    self.simulation_data = trajectory_base
+                self.simulation_data = []
+                for trajectory in range(number_of_trajectories):
+                    data = {'time': trajectory_base[trajectory, :, 0]}
+                    for i in range(len(self.species)):
+                        data[self.species[i]] = trajectory_base[trajectory, :, i+1]
+                    self.simulation_data.append(data)
+
             else:
-                raise gillespyError.ExecutionError("Error encountered while running simulation C++ file:\nReturn code: {0}.\nError:\n{1}\n".format(simulation.returncode, simulation.stderr))
+                raise gillespyError.ExecutionError("Error encountered while running simulation C++ file:"
+                                                   "\nReturn code: {0}.\nError:\n{1}\n".format(simulation.returncode,
+                                                                                               simulation.stderr))
         return self.simulation_data, return_code
 

--- a/gillespy2/solvers/numpy/basic_ode_solver.py
+++ b/gillespy2/solvers/numpy/basic_ode_solver.py
@@ -54,12 +54,10 @@ class BasicODESolver(GillesPySolver):
         """
         :return: Tuple of strings, denoting all keyword argument for this solvers run() method.
         """
-        return ('model', 't', 'number_of_trajectories', 'increment', 'show_labels', 'integrator', 'integrator_options'
-                'timeout')
+        return ('model', 't', 'number_of_trajectories', 'increment', 'integrator', 'integrator_options' 'timeout')
 
     @classmethod
-    def run(self, model, t=20, number_of_trajectories=1, increment=0.05, 
-            show_labels=True, integrator='lsoda', integrator_options={}, 
+    def run(self, model, t=20, number_of_trajectories=1, increment=0.05, integrator='lsoda', integrator_options={},
             timeout=None, **kwargs):
         """
 
@@ -68,7 +66,6 @@ class BasicODESolver(GillesPySolver):
         :param number_of_trajectories: Should be 1.
             This is deterministic and will always have same results
         :param increment: time step increment for plotting
-        :param show_labels: If true, simulation returns a list of trajectories, where each list entry is a dictionary containing key value pairs of species : trajectory.  If false, returns a numpy array with shape [traj_no, time, species]
         :param integrator: integrator to be used form scipy.integrate.ode. Options include 'vode', 'zvode', 'lsoda', 'dopri5', and 'dop835'.  For more details, see https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.ode.html
         :param integrator_options: a dictionary containing options to the scipy integrator. for a list of options, see https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.ode.html.
             Example use: {max_step : 0, rtol : .01}
@@ -86,9 +83,7 @@ class BasicODESolver(GillesPySolver):
             log.warning("Generating duplicate trajectories for model with ODE Solver. Consider running with only 1 trajectory.")
         sim_thread = Thread(target=self.___run, args=(model,), kwargs={'t':t,
                                         'number_of_trajectories':number_of_trajectories,
-                                        'increment':increment, 'show_labels':show_labels, 
-                                        'timeout':timeout,
-                                        'integrator':integrator,
+                                        'increment':increment, 'timeout':timeout, 'integrator':integrator,
                                         'integrator_options':integrator_options})
         try:
             sim_thread.start()
@@ -101,18 +96,17 @@ class BasicODESolver(GillesPySolver):
             raise self.has_raised_exception
         return self.result, self.rc
 
-    def ___run(self, model, t=20, number_of_trajectories=1, increment=0.05, timeout=None,
-            show_labels=True, integrator='lsoda', integrator_options={}, **kwargs):
+    def ___run(self, model, t=20, number_of_trajectories=1, increment=0.05, timeout=None, integrator='lsoda',
+               integrator_options={}, **kwargs):
         try:
-            self.__run(model, t, number_of_trajectories, increment, timeout,
-                        show_labels, integrator, integrator_options, **kwargs)
+            self.__run(model, t, number_of_trajectories, increment, timeout, integrator, integrator_options, **kwargs)
         except Exception as e:
             self.has_raised_exception = e
             self.result = []
             return [], -1
 
-    def __run(self, model, t=20, number_of_trajectories=1, increment=0.05, timeout=None,
-            show_labels=True, integrator='lsoda', integrator_options={}, **kwargs):
+    def __run(self, model, t=20, number_of_trajectories=1, increment=0.05, timeout=None, integrator='lsoda',
+              integrator_options={}, **kwargs):
 
         start_state = [model.listOfSpecies[species].initial_value for species in model.listOfSpecies]
 
@@ -166,14 +160,13 @@ class BasicODESolver(GillesPySolver):
                 curr_state[spec] = y0[i]
                 result[entry_count][i+1] = curr_state[spec]
 
-        if show_labels:
-            results_as_dict = {
-                'time': timeline
-            }
-            for i, species in enumerate(model.listOfSpecies):
-                results_as_dict[species] = result[:, i+1]
-            results = [results_as_dict] * number_of_trajectories
-        else:
-            results = np.stack([result] * number_of_trajectories, axis=0)
+        #Turn trajectory into dictionary indexed by species/time
+        results_as_dict = {
+            'time': timeline
+        }
+        for i, species in enumerate(model.listOfSpecies):
+            results_as_dict[species] = result[:, i+1]
+        results = [results_as_dict] * number_of_trajectories
+
         self.result = results
         return results, self.rc

--- a/gillespy2/solvers/numpy/basic_tau_hybrid_solver.py
+++ b/gillespy2/solvers/numpy/basic_tau_hybrid_solver.py
@@ -724,12 +724,11 @@ class BasicTauHybridSolver(GillesPySolver):
         """
         :return: Tuple of strings, denoting all keyword argument for this solvers run() method.
         """
-        return ('model', 't', 'number_of_trajectories', 'increment', 'seed', 'debug', 'profile', 'show_labels',
-                'tau_tol', 'event_sensitivity', 'integrator', 'integrator_options', 'timeout')
+        return ('model', 't', 'number_of_trajectories', 'increment', 'seed', 'debug', 'profile', 'tau_tol',
+                'event_sensitivity', 'integrator', 'integrator_options', 'timeout')
     @classmethod
     def run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None, 
-            debug=False, profile=False, show_labels=True,
-            tau_tol=0.03, event_sensitivity=100, integrator='LSODA',
+            debug=False, profile=False, tau_tol=0.03, event_sensitivity=100, integrator='LSODA',
             integrator_options={}, timeout=None, **kwargs):
         """
         Function calling simulation of the model. This is typically called by the run function in GillesPy2 model
@@ -755,8 +754,6 @@ class BasicTauHybridSolver(GillesPySolver):
             simulation.
         profile : bool (Fasle)
             Set to True to provide information about step size (tau) taken at each step.
-        show_labels: bool (True)
-            If true, simulation returns a list of trajectories, where each list entry is a dictionary containing key value pairs of species : trajectory.  If false, returns a numpy array with shape [traj_no, time, species]
         tau_tol: float
             Tolerance level for Tau leaping algorithm.  Larger tolerance values will
             result in larger tau steps. Default value is 0.03.
@@ -788,7 +785,7 @@ class BasicTauHybridSolver(GillesPySolver):
         sim_thread = threading.Thread(target=self.___run, args=(model,), kwargs={'t':t,
                                         'number_of_trajectories':number_of_trajectories,
                                         'increment':increment, 'seed':seed,
-                                        'debug':debug, 'profile':profile,'show_labels':show_labels,
+                                        'debug':debug, 'profile':profile,
                                         'timeout':timeout, 'tau_tol':tau_tol,
                                         'event_sensitivity':event_sensitivity,
                                         'integrator':integrator,
@@ -807,20 +804,18 @@ class BasicTauHybridSolver(GillesPySolver):
 
 
     def ___run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None, 
-            debug=False, profile=False, show_labels=True,
-            tau_tol=0.03, event_sensitivity=100, integrator='LSODA',
-            integrator_options={}, **kwargs):
+            debug=False, profile=False, tau_tol=0.03, event_sensitivity=100, integrator='LSODA', integrator_options={},
+               **kwargs):
             try:
-                self.__run(model,t,number_of_trajectories, increment, seed, debug,
-                           profile,show_labels, tau_tol, event_sensitivity, integrator,
-                           integrator_options, **kwargs)
+                self.__run(model, t, number_of_trajectories, increment, seed, debug,
+                           profile, tau_tol, event_sensitivity, integrator, integrator_options, **kwargs)
             except Exception as e:
                 self.has_raised_exception = e
                 self.result = []
                 return [], -1
                 
     def __run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None, 
-            debug=False, profile=False, show_labels=True,
+            debug=False, profile=False,
             tau_tol=0.03, event_sensitivity=100, integrator='LSODA',
             integrator_options={}, **kwargs):
 
@@ -911,8 +906,8 @@ class BasicTauHybridSolver(GillesPySolver):
             curr_time = 0 # Current Simulation Time
             end_time = model.tspan[-1] # End of Simulation time
             entry_pos = 1
-            data = OrderedDict() # Dictionary for show_labels results
-            data['time'] = timeline # All time entries for show_labels results
+            data = OrderedDict() # Dictionary for results
+            data['time'] = timeline # All time entries
             save_times = timeline
             
 
@@ -1000,18 +995,10 @@ class BasicTauHybridSolver(GillesPySolver):
                     event_sensitivity, tau_step, pure_ode, debug)
 
             # End of trajectory, format results
-            if show_labels:
-                data = {'time':timeline}
-                for i in range(number_species):
-                    data[species[i]] = trajectory[:, i+1]
-                simulation_data.append(data)
-            else:
-                simulation_data = trajectory_base
-
-            if profile:
-                print(steps_taken)
-                print("Total Steps Taken: ", len(steps_taken))
-                print("Total Steps Rejected: ", steps_rejected)
+            data = {'time':timeline}
+            for i in range(number_species):
+                data[species[i]] = trajectory[:, i+1]
+            simulation_data.append(data)
 
         self.result = simulation_data
         return simulation_data, self.rc

--- a/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
+++ b/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
@@ -64,12 +64,10 @@ class BasicTauLeapingSolver(GillesPySolver):
         """
         :return: Tuple of strings, denoting all keyword argument for this solvers run() method.
         """
-        return ('model', 't', 'number_of_trajectories', 'increment', 'seed', 'debug', 'profile', 'show_labels',
-                'timeout', 'tau_tol')
+        return ('model', 't', 'number_of_trajectories', 'increment', 'seed', 'debug', 'profile', 'timeout', 'tau_tol')
     @classmethod
-    def run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None,
-                    debug=False, profile=False, show_labels=True, 
-                    timeout=None, tau_tol=0.03, **kwargs):
+    def run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None, debug=False, profile=False,
+            timeout=None, tau_tol=0.03, **kwargs):
         """
         Function calling simulation of the model.
         This is typically called by the run function in GillesPy2 model objects
@@ -96,8 +94,6 @@ class BasicTauLeapingSolver(GillesPySolver):
                     simulation.
                 profile : bool (Fasle)
                     Set to True to provide information about step size (tau) taken at each step.
-                show_labels : bool (True)
-                    Use names of species as index of result object rather than position numbers.
                 """
 
         if isinstance(self, type):
@@ -110,15 +106,16 @@ class BasicTauLeapingSolver(GillesPySolver):
                 log.warning('Unsupported keyword argument to {0} solver: {1}'.format(self.name, key))
 
         sim_thread = Thread(target=self.___run, args=(model,), kwargs={'t':t,
-                                        'number_of_trajectories':number_of_trajectories,
-                                        'increment':increment, 'seed':seed,
-                                        'debug':debug, 'show_labels':show_labels,
-                                        'timeout':timeout, 'tau_tol':tau_tol})
+                                                                       'number_of_trajectories':number_of_trajectories,
+                                                                       'increment':increment, 'seed':seed,
+                                                                       'debug':debug, 'timeout':timeout,
+                                                                       'tau_tol':tau_tol})
         try:
             sim_thread.start()
             sim_thread.join(timeout=timeout)
             self.stop_event.set()
             while self.result is None: pass
+
         except:
             pass
         if hasattr(self, 'has_raised_exception'):
@@ -126,11 +123,10 @@ class BasicTauLeapingSolver(GillesPySolver):
         return self.result, self.rc
 
     def ___run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None,
-                    debug=False, profile=False, show_labels=True, 
-                    timeout=None, tau_tol=0.03, **kwargs):
+               debug=False, profile=False, timeout=None, tau_tol=0.03, **kwargs):
         try:
             self.__run(model, t, number_of_trajectories, increment, seed,
-                        debug, profile, show_labels, timeout, tau_tol, **kwargs)
+                        debug, profile, timeout, tau_tol, **kwargs)
         except Exception as e:
             self.has_raised_exception = e
             self.result = []
@@ -138,8 +134,7 @@ class BasicTauLeapingSolver(GillesPySolver):
 
 
     def __run(self, model, t=20, number_of_trajectories=1, increment=0.05, seed=None,
-                    debug=False, profile=False, show_labels=True, 
-                    timeout=None, tau_tol=0.03, **kwargs):
+                    debug=False, profile=False, timeout=None, tau_tol=0.03, **kwargs):
 
         if debug:
             print("t = ", t)
@@ -297,12 +292,10 @@ class BasicTauLeapingSolver(GillesPySolver):
                 entry_count += 1
                 
             # end of trajectory
-            if show_labels:
-                for i in range(number_species):
-                    data[species[i]] = trajectory[:, i+1]
-                simulation_data.append(data)
-            else:
-                simulation_data = trajectory_base
+            for i in range(number_species):
+                data[species[i]] = trajectory[:, i+1]
+            simulation_data.append(data)
+
             if profile:
                 print(steps_taken)
                 print("Total Steps Taken: ", len(steps_taken))

--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -21,11 +21,11 @@ class NumPySSASolver(GillesPySolver):
         """
         :return: Tuple of strings, denoting all keyword argument for this solvers run() method.
         """
-        return ('model', 't', 'number_of_trajectories', 'increment', 'seed', 'debug', 'show_labels', 'timeout')
+        return ('model', 't', 'number_of_trajectories', 'increment', 'seed', 'debug', 'timeout')
 
     @classmethod
     def run(self, model, t=20, number_of_trajectories=1, increment=0.05,
-                        seed=None, debug=False, show_labels=True, timeout=None, **kwargs):
+                        seed=None, debug=False, timeout=None, **kwargs):
         """
         Run the SSA algorithm using a NumPy for storing the data in arrays and generating the timeline.
         :param model: The model on which the solver will operate.
@@ -36,7 +36,6 @@ class NumPySSASolver(GillesPySolver):
         :param seed: The random seed for the simulation. Defaults to None.
         :param debug: Set to True to provide additional debug information about the
         simulation.
-        :param show_labels: Use names of species as index of result object rather than position numbers.
         :return: a list of each trajectory simulated.
         """
 
@@ -53,8 +52,7 @@ class NumPySSASolver(GillesPySolver):
         sim_thread = Thread(target=self.___run, args=(model,), kwargs={'t':t,
                                         'number_of_trajectories':number_of_trajectories,
                                         'increment':increment, 'seed':seed,
-                                        'debug':debug, 'show_labels':show_labels,
-                                        'timeout':timeout})
+                                        'debug':debug, 'timeout':timeout})
         try:
             sim_thread.start()
             sim_thread.join(timeout=timeout)
@@ -67,17 +65,16 @@ class NumPySSASolver(GillesPySolver):
         return self.result, self.rc
 
     def ___run(self, model, t=20, number_of_trajectories=1, increment=0.05,
-                    seed=None, debug=False, show_labels=True, timeout=None):
+                    seed=None, debug=False, timeout=None):
         try:
-            self.__run(model, t, number_of_trajectories, increment, seed,
-                            debug, show_labels, timeout)
+            self.__run(model, t, number_of_trajectories, increment, seed, debug, timeout)
         except Exception as e:
             self.has_raised_exception = e
             self.result = []
             return [], -1
 
     def __run(self, model, t=20, number_of_trajectories=1, increment=0.05,
-                    seed=None, debug=False, show_labels=True, timeout=None):
+                    seed=None, debug=False, timeout=None):
 
         random.seed(seed)
         # create mapping of species dictionary to array indices
@@ -178,14 +175,13 @@ class NumPySSASolver(GillesPySolver):
                             if debug:
                                 print('new propensity sum: ', propensity_sums[i])
                         break
-            if show_labels:
-                data = {
-                    'time': timeline
-                }
-                for i in range(number_species):
-                    data[species[i]] = trajectory[:, i+1]
-                simulation_data.append(data)
-            else:
-                simulation_data = trajectory_base
+            #Append labels to trajectory base
+            data = {
+                'time': timeline
+            }
+            for i in range(number_species):
+                data[species[i]] = trajectory[:, i+1]
+            simulation_data.append(data)
+
         self.result = simulation_data
         return self.result, self.rc

--- a/test/test_all_solvers.py
+++ b/test/test_all_solvers.py
@@ -25,20 +25,17 @@ class TestAllSolvers(unittest.TestCase):
     labeled_results_more_trajectories = {}
 
     for solver in solvers:
-        results[solver] = model.run(solver=solver, show_labels=False, seed=1)
-        labeled_results[solver] = model.run(solver=solver, show_labels=True,number_of_trajectories=1)
-        labeled_results_more_trajectories[solver] = model.run(solver=solver, show_labels=True,number_of_trajectories=2)
+        labeled_results[solver] = model.run(solver=solver, number_of_trajectories=1,seed=1)
+        labeled_results_more_trajectories[solver] = model.run(solver=solver, number_of_trajectories=2)
 
     def test_instantiated(self):
         for solver in self.solvers:
             self.model.run(solver=solver())
 
-    def test_return_type(self):
+    def test_to_array(self):
         for solver in self.solvers:
-            self.assertTrue(isinstance(self.results[solver], np.ndarray))
-            self.assertTrue(isinstance(self.results[solver][0], np.ndarray))
-            self.assertTrue(isinstance(self.results[solver][0][0], np.ndarray))
-            self.assertTrue(isinstance(self.results[solver][0][0][0], np.float))
+            print(self.labeled_results[solver].to_array(),type(self.labeled_results[solver].to_array()[0]))
+            self.assertTrue(isinstance(self.labeled_results[solver].to_array(), np.ndarray))
 
     def test_return_type_show_labels(self):
         for solver in self.solvers:
@@ -56,11 +53,12 @@ class TestAllSolvers(unittest.TestCase):
 
     def test_random_seed(self):
         for solver in self.solvers:
-            same_results = self.model.run(solver=solver, show_labels=False, seed=1)
-            self.assertTrue(np.array_equal(same_results, self.results[solver]))
+            same_results = self.model.run(solver=solver, seed=1)
+            compare_results = self.model.run(solver=solver,seed=1)
+            self.assertTrue(np.array_equal(same_results.to_array(), compare_results.to_array()))
             if solver.name == 'BasicODESolver': continue
-            diff_results = self.model.run(solver=solver, show_labels=False, seed=2)
-            self.assertFalse(np.array_equal(diff_results, self.results[solver]))
+            diff_results = self.model.run(solver=solver, seed=2)
+            self.assertFalse(np.array_equal(diff_results.to_array(),same_results.to_array()))
     
     def test_extraneous_args(self):
         for solver in self.solvers:

--- a/test/test_all_solvers.py
+++ b/test/test_all_solvers.py
@@ -34,8 +34,7 @@ class TestAllSolvers(unittest.TestCase):
 
     def test_to_array(self):
         for solver in self.solvers:
-            print(self.labeled_results[solver].to_array(),type(self.labeled_results[solver].to_array()[0]))
-            self.assertTrue(isinstance(self.labeled_results[solver].to_array(), np.ndarray))
+            self.assertTrue(isinstance(self.labeled_results[solver].to_array()[0], np.ndarray))
 
     def test_return_type_show_labels(self):
         for solver in self.solvers:


### PR DESCRIPTION
 - show_labels defaults to True, if specified as False, throw warning in the gillespy2.py run() method, telling the user the show_labels=False feature is being deprecated

- add to_array() method for a Results object in results.py, if show_labels specified to False in the gillespy2.py run() method, call to_array on results object, return it

- Remove superfluous and unnecessary code in solvers, as well as the gillespy2.py run() method

- Format for pep8 throughout solvers, remove all mention of show_labels from the solvers.