### PR TITLE
plotplotly std_dev_range() fixes

### DIFF
--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -411,15 +411,15 @@ class Results(UserList):
                 else:
                     trace_list = _plotplotly_iterate(trajectory, trace_list=[], included_species_list=included_species_list)
 
-                for k in range(0,len(trace_list)):
-                    if i%2 == 0:
+                for k in range(0, len(trace_list)):
+                    if i % 2 == 0:
                         fig.append_trace(trace_list[k], int(i/2) + 1, 1)
                     else:
                         fig.append_trace(trace_list[k], int(i/2) + 1, 2)
 
                 fig['layout'].update(autosize=True,
                                      height=400*len(trajectory_list),
-                                     showlegend=show_legend,title =title)
+                                     showlegend=show_legend, title=title)
 
             
 
@@ -575,7 +575,6 @@ class Results(UserList):
 
         average_trajectory = self.average_ensemble().data[0]
         stddev_trajectory = self.stddev_ensemble(ddof= ddof).data[0]
-
         from plotly.offline import init_notebook_mode, iplot
         import plotly.graph_objs as go
 
@@ -587,7 +586,7 @@ class Results(UserList):
             if title is None:
                 title = (self._validate_title(show_title) + " - Standard Deviation Range")
 
-        trace_list=[]
+        trace_list = []
         for species in average_trajectory:
             if species != 'time':
 
@@ -643,6 +642,7 @@ class Results(UserList):
             title=title,
             xaxis_title=xaxis_label,
             yaxis_title=yaxis_label,
+            legend={'traceorder': 'normal'},
             **layout_args
         )
         fig = dict(data=trace_list, layout=layout)

--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -594,18 +594,21 @@ class Results(UserList):
                     continue
 
                 upper_bound = []
+                lower_bound = []
                 for i in range(0, len(average_trajectory[species])):
                     upper_bound.append(average_trajectory[species][i] + stddev_trajectory[species][i])
+                    lower_bound.append(average_trajectory[species][i] - stddev_trajectory[species][i])
 
+                # Append upper_bound list to trace_list
                 trace_list.append(
                     go.Scatter(
                         name=species+ ' Upper Bound',
                         x=average_trajectory['time'],
-                        y = upper_bound,
+                        y=upper_bound,
                         mode='lines',
                         marker=dict(color="#444"),
                         line=dict(width=1,dash='dot'),
-                        legendgroup="Standard Deviation",
+                        legendgroup=str(average_trajectory[species]),
                         showlegend=False
                     )
                 )
@@ -615,14 +618,12 @@ class Results(UserList):
                         y=average_trajectory[species],
                         name=species,
                         fillcolor='rgba(68, 68, 68, 0.2)',
-                        fill='tonexty'
+                        fill='tonexty',
+                        legendgroup=str(average_trajectory[species]),
                     )
                 )
 
-                lower_bound = []
-                for i in range(0, len(average_trajectory[species])):
-                    lower_bound.append(average_trajectory[species][i] - stddev_trajectory[species][i])
-
+                # Append lower_bound list to trace_list
                 trace_list.append(
                     go.Scatter(
                         name=species + ' Lower Bound',
@@ -633,10 +634,12 @@ class Results(UserList):
                         line=dict(width=1,dash='dot'),
                         fillcolor='rgba(68, 68, 68, 0.2)',
                         fill='tonexty',
-                        legendgroup="Standard Deviation",
+                        legendgroup=str(average_trajectory[species]),
                         showlegend=False
                     )
                 )
+
+
         layout = go.Layout(
             showlegend=show_legend,
             title=title,

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -57,8 +57,9 @@ class TestResults(unittest.TestCase):
         with mock.patch('plotly.offline.init_notebook_mode') as mock_notebook:
             with mock.patch('plotly.graph_objs.Scatter') as mock_scatter:
                 with mock.patch('plotly.graph_objs.Layout') as mock_layout:
-                    results.plotplotly_std_dev_range(return_plotly_figure=True,xscale='log')
-        mock_layout.assert_called_with(showlegend=True, title='Standard Deviation Range', xaxis_title='Time ', xscale='log', yaxis_title='Species Population') 
+                    results.plotplotly_std_dev_range(return_plotly_figure=True, xscale='log')
+        mock_layout.assert_called_with(legend={'traceorder':'normal'},showlegend=True, title='Standard Deviation Range',
+                                       xaxis_title='Time ', xscale='log', yaxis_title='Species Population')
 
     def test_pickle_stable_plot_iterate(self):
         from unittest import mock


### PR DESCRIPTION
- Fix species being graphed in reverse order in the results.plotploty_std_dev_range() method
- Make it so that, when a species is unselected in a results.plotploty_std_dev_range() plot, the std dev range is ALSO unselected. This is by making each species and std dev range for that species part of their own group. When unselecting an item that is part of a group in plotly, ALL members of that group are also unselected
- Re order how std dev is calculated, so that only one (instead of two) for loops are used. 