### PR TITLE
Windows C++ Solver fix, for fail on Popen() line

### DIFF
--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -259,8 +259,8 @@ class SSACSolver(GillesPySolver):
                     else:
                         raise gillespyError.ModelError("seed must be a positive integer")
 
-            #begin subprocess c simulation with timeout (default timeout=0 will not timeout)
-            with subprocess.Popen(args, stdout=subprocess.PIPE, preexec_fn=os.setsid) as simulation:
+            # begin subprocess c simulation with timeout (default timeout=0 will not timeout)
+            with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
                 return_code = 0
                 try:
                     if timeout > 0:

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -320,7 +320,7 @@ class VariableSSACSolver(GillesPySolver):
                         raise ModelError("seed must be a positive integer")
 
             #begin subprocess c simulation with timeout (default timeout=0 will not timeout)
-            with subprocess.Popen(args, stdout=subprocess.PIPE, preexec_fn=os.setsid) as simulation:
+            with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
                 try:
                     if timeout > 0:
                         stdout, stderr = simulation.communicate(timeout=timeout)

--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -92,7 +92,6 @@ class NumPySSASolver(GillesPySolver):
         timeStopped = 0
 
         if resume is not None:
-            print(resume[0].model == model)
             if resume[0].model != model:
                 raise gillespyError.ModelError('When resuming, one must not alter the model being resumed.')
             if t < resume['time'][-1]:


### PR DESCRIPTION
- Remove printline in numpySSASolver

-  Change preexec_fn with start_new_session=True (os.setsid() not supported by Windows)
https://stackoverflow.com/questions/42257512/difference-between-subprocess-popen-preexec-fn-and-start-new-session-in-python