### PR TITLE
Fix pause resume bad data output, BasicODE, SSA_Solver, VariableSSACSolver

### DIFF
--- a/gillespy2/solvers/numpy/basic_ode_solver.py
+++ b/gillespy2/solvers/numpy/basic_ode_solver.py
@@ -165,9 +165,12 @@ class BasicODESolver(GillesPySolver):
             c_prop[r_name] = compile(reaction.ode_propensity_function, '<string>', 'eval')
 
         result = trajectory_base[0]
-        curr_time = 0
-        entry_count = 0
+        if resume is not None:
+            curr_time = resume['time'][-1]
+        else:
+            curr_time = 0
 
+        entry_count = 0
         y0 = [0] * len(model.listOfSpecies)
         curr_state = OrderedDict()
 

--- a/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
+++ b/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
@@ -211,9 +211,15 @@ class BasicTauLeapingSolver(GillesPySolver):
             start_state = [0] * (len(model.listOfReactions) + len(model.listOfRateRules))
             propensities = {}
             curr_state = {}
-            curr_time = 0
+
+            if resume is not None:
+                curr_time = resume['time'][-1]
+                save_time = resume['time'][-1]
+            else:
+                curr_time = 0
+                save_time = 0
+
             curr_state['vol'] = model.volume
-            save_time = 0
             data = { 'time': timeline}
             steps_taken = []
             steps_rejected = 0

--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -171,7 +171,10 @@ class NumPySSASolver(GillesPySolver):
             # copy initial state data
             trajectory = trajectory_base[trajectory_num]
             entry_count = 1
-            current_time = 0
+            if resume is not None:
+                current_time = resume['time'][-1]
+            else:
+                current_time = 0
             current_state = np.copy(trajectory[0, 1:])
             propensity_sums = np.zeros(number_reactions)
             # calculate initial propensity sums


### PR DESCRIPTION
-  When resuming, current time was not resumed for basic_ode_solvery and ssa_solver.py. I.e If you ran a simulation to 100, and resumed it to 200, your current time would be 0 going to 200, rather than 100 going to 200.

- For the variable_ssa_c_solver.py, added a line to ensure correct species populations are sent to c base when resuming, previously, they were being sent as the initial value of the species from the original model, not where the model last left off prior to resume.

- Delete unused code in variable_ssa_c_solver.py, including trailing semicolons, unused functions, and pause/resume features pertaining to the now deprecated show_labels==False option