### PR TITLE
Progress bar fixes for new curr_time fixes

### DIFF
--- a/gillespy2/core/liveGraphing.py
+++ b/gillespy2/core/liveGraphing.py
@@ -39,11 +39,12 @@ class LiveDisplayer():
     holds information required for displaying information when live_output = True
     """
 
-    def __init__(self,model = None,timeline=None,number_of_trajectories=1,live_output_options = {} ):
+    def __init__(self,model = None,timeline=None,number_of_trajectories=1,live_output_options = {},resume=False):
 
         self.display_type = live_output_options['type']
         self.display_interval = live_output_options['interval']
         self.model = model
+        self.resume = resume
         self.timeline = timeline
         self.timeline_len = timeline.size
         self.x_shift = int(timeline[0])
@@ -82,8 +83,7 @@ class LiveDisplayer():
 
         from IPython.display import clear_output
         from math import floor
-
-        curr_time = curr_time[0] + self.timeline[0]
+        curr_time = curr_time[0]
         curr_state = curr_state[0]
 
         #necessary for __f function in hybrid solver
@@ -113,8 +113,11 @@ class LiveDisplayer():
 
                 if self.number_of_trajectories > 1:
                     print(self.trajectory_header())
-
-                print("progress =", round((curr_time / (self.timeline_len + self.x_shift)) * 100, 2), "%\n")
+                if self.resume is True:
+                    print("progress =", round(((curr_time-self.x_shift)/(self.timeline_len))*100, 2), "%\n"
+                          )
+                else:
+                    print("progress =", round((curr_time / (self.timeline_len + self.x_shift)) * 100, 2), "%\n")
 
             elif self.display_type == "graph":
 

--- a/gillespy2/solvers/numpy/basic_ode_solver.py
+++ b/gillespy2/solvers/numpy/basic_ode_solver.py
@@ -110,7 +110,10 @@ class BasicODESolver(GillesPySolver):
         trajectory_base[:, :, 0] = timeline
 
         # curr_time and curr_state are list of len 1 so that __run receives reference
-        curr_time = [0]  # Current Simulation Time
+        if resume is not None:
+            curr_time = [resume['time'][-1]]
+        else:
+            curr_time = [0] # Current Simulation Time
         curr_state = [None]
         live_grapher = [None]
 
@@ -135,10 +138,13 @@ class BasicODESolver(GillesPySolver):
                             log.warning(
                                 'display "\type\" = \"graph\" not recommended with continuous species. Try display \"type\" = \"text\" or \"progress\".')
                             break
-
+                if resume is not None:
+                    resumeTest = True  # If resuming, relay this information to live_grapher
+                else:
+                    resumeTest = False
                 live_grapher[0] = gillespy2.core.liveGraphing.LiveDisplayer(model,
                                                                             timeline, number_of_trajectories,
-                                                                            live_output_options)
+                                                                            live_output_options, resume=resumeTest)
                 display_timer = gillespy2.core.liveGraphing.RepeatTimer(live_output_options['interval'],
                                                                         live_grapher[0].display,
                                                                         args=(curr_state, curr_time, trajectory_base,))
@@ -211,7 +217,6 @@ class BasicODESolver(GillesPySolver):
             c_prop[r_name] = compile(reaction.ode_propensity_function, '<string>', 'eval')
 
         result = trajectory_base[0]
-        curr_time[0] = 0
         entry_count = 0
 
         y0 = [0] * len(model.listOfSpecies)

--- a/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
+++ b/gillespy2/solvers/numpy/basic_tau_leaping_solver.py
@@ -149,7 +149,11 @@ class BasicTauLeapingSolver(GillesPySolver):
         trajectory_base[:, :, 0] = timeline
 
         # curr_time and curr_state are list of len 1 so that __run receives reference
-        curr_time = [0]  # Current Simulation Time
+        if resume is not None:
+            curr_time = [resume['time'][-1]]
+        else:
+            curr_time = [0]
+
         curr_state = [None]
         live_grapher = [None]
 
@@ -170,11 +174,14 @@ class BasicTauLeapingSolver(GillesPySolver):
                     for i, s in enumerate(list(model._listOfSpecies.keys())):
 
                         if model.listOfSpecies[s].mode is 'continuous':
-                            log.warning('display "\type\" = \"graph\" not recommended with continuous species. Try display \"type\" = \"text\" or \"progress\".')
+                            log.warning('display "\type\" = \"graph\" not recommended with continuous species. '
+                                        'Try display \"type\" = \"text\" or \"progress\".')
                             break
-
-                live_grapher[0] = gillespy2.core.liveGraphing.LiveDisplayer( model,
-                                                                            timeline, number_of_trajectories,live_output_options)
+                if resume is not None:
+                    resumeTest = True  # If resuming, relay this information to live_grapher
+                else:
+                    resumeTest = False
+                live_grapher[0] = gillespy2.core.liveGraphing.LiveDisplayer(model,timeline, number_of_trajectories,live_output_options,resume=resumeTest)
                 display_timer = gillespy2.core.liveGraphing.RepeatTimer(live_output_options['interval'], live_grapher[0].display,
                                                                         args=(curr_state, curr_time, trajectory_base,))
                 display_timer.start()
@@ -271,9 +278,12 @@ class BasicTauLeapingSolver(GillesPySolver):
             start_state = [0] * (len(model.listOfReactions) + len(model.listOfRateRules))
             propensities = {}
             curr_state[0] = {}
-            curr_time[0] = 0
+            if resume is not None:
+                save_time = curr_time[0]
+            else:
+                save_time = 0
+
             curr_state[0]['vol'] = model.volume
-            save_time = 0
             data = { 'time': timeline}
             steps_taken = []
             steps_rejected = 0

--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -91,7 +91,10 @@ class NumPySSASolver(GillesPySolver):
                 trajectory_base[:, 0, i + 1] = model.listOfSpecies[s].initial_value
 
         # curr_time and curr_state are list of len 1 so that __run receives reference
-        curr_time = [0]  # Current Simulation Time
+        if resume is not None:
+            curr_time = [resume['time'][-1]]
+        else:
+            curr_time = [0]
         curr_state = [None]
         live_grapher = [None]
 
@@ -116,9 +119,12 @@ class NumPySSASolver(GillesPySolver):
                         if model.listOfSpecies[s].mode is 'continuous':
                             log.warning('display "\type\" = \"graph\" not recommended with continuous species. Try display \"type\" = \"text\" or \"progress\".')
                             break
-
+                if resume is not None:
+                    resumeTest = True  # If resuming, relay this information to live_grapher
+                else:
+                    resumeTest = False
                 live_grapher[0] = gillespy2.core.liveGraphing.LiveDisplayer( model,
-                                                                            timeline, number_of_trajectories,live_output_options)
+                                                                            timeline, number_of_trajectories,live_output_options,resume = resumeTest)
                 display_timer = gillespy2.core.liveGraphing.RepeatTimer(live_output_options['interval'], live_grapher[0].display,
                                                                         args=(curr_state, curr_time, trajectory_base,))
                 display_timer.start()
@@ -217,12 +223,13 @@ class NumPySSASolver(GillesPySolver):
             # copy initial state data
             trajectory = trajectory_base[trajectory_num]
             entry_count = 1
-            curr_time[0] = 0
             curr_state[0] = {}
 
             for spec in model.listOfSpecies:
-                # initialize populations
-                curr_state[0][spec] = model.listOfSpecies[spec].initial_value
+                if resume is not None:
+                    curr_state[0][spec] = resume[spec][-1]
+                else:
+                    curr_state[0][spec] = model.listOfSpecies[spec].initial_value
 
             propensity_sums = np.zeros(number_reactions)
             # calculate initial propensity sums
@@ -261,16 +268,14 @@ class NumPySSASolver(GillesPySolver):
                     print('curr_time: ', curr_time[0])
                 # determine time passed in this reaction
 
-                while entry_count < timeline.size and timeline[entry_count] <= curr_time[0] + timeline[0]:
+                while entry_count < timeline.size and timeline[entry_count] <= curr_time[0]:
                     if self.stop_event.is_set():
                         self.rc = 33
                         break
                     elif self.pause_event.is_set():
                         timeStopped = timeline[entry_count]
                         break
-
                     trajectory[entry_count, 1:] = species_states
-
                     entry_count += 1
 
                 for potential_reaction in range(number_reactions):
@@ -278,12 +283,10 @@ class NumPySSASolver(GillesPySolver):
                     if debug:
                         print('if <=0, fire: ', cumulative_sum)
                     if cumulative_sum <= 0:
-                        for i,spec in enumerate(model.listOfSpecies):
+                        for i, spec in enumerate(model.listOfSpecies):
                             curr_state[0][spec] += species_changes[potential_reaction][i]
 
                         reacName = reactions[potential_reaction]
-
-
                         if debug:
                             print('current state: ', curr_state[0])
                             print('species_changes: ', species_changes)


### PR DESCRIPTION
-  When resuming, current time was not resumed for basic_ode_solver.py and ssa_solver.py, or tau leaping solver. I.e If you ran a simulation to 100, and resumed it to 200, your current time would be 0 going to 200, rather than 100 going to 200.

- When I fixed this, this broke some things in live_graphing. I've changed the way that progress bars are calculated, to allow these fixes to work.