### PR TITLE
Fix for multi trajectories

### DIFF
--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -56,7 +56,6 @@ class NumPySSASolver(GillesPySolver):
 
         if timeout is not None and timeout <= 0:
             timeout = None
-
         if len(kwargs) > 0:
             for key in kwargs:
                 log.warning('Unsupported keyword argument to {0} solver: {1}'.format(self.name, key))
@@ -80,6 +79,7 @@ class NumPySSASolver(GillesPySolver):
             total_time = [resume['time'][-1]]
         else:
             total_time = [0]
+
         curr_state = [None]
         live_grapher = [None]
 
@@ -191,6 +191,7 @@ class NumPySSASolver(GillesPySolver):
         # begin simulating each trajectory
         simulation_data = []
         for trajectory_num in range(number_of_trajectories):
+            total_time[0] = 0
             if self.stop_event.is_set():
                 self.rc = 33
                 break
@@ -211,8 +212,6 @@ class NumPySSASolver(GillesPySolver):
                 curr_time = [resume['time'][-1]]
             else:
                 curr_time = [0]
-
-
 
             for spec in model.listOfSpecies:
                 if resume is not None:

--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -79,11 +79,11 @@ class NumPySSASolver(GillesPySolver):
         if resume is not None:
             curr_time = [resume['time'][-1]]
         else:
-            curr_time = [0]
+            total_time = [0]
         curr_state = [None]
         live_grapher = [None]
 
-        sim_thread = Thread(target=self.___run, args=(model, curr_state, curr_time, timeline, trajectory_base,
+        sim_thread = Thread(target=self.___run, args=(model, curr_state, total_time, timeline, trajectory_base,
                                                       live_grapher,), kwargs={'t': t, 'number_of_trajectories':
                                                                               number_of_trajectories,
                                                                               'increment': increment,
@@ -105,7 +105,7 @@ class NumPySSASolver(GillesPySolver):
                                                                              live_output_options,resume = resumeTest)
                 display_timer = gillespy2.core.liveGraphing.RepeatTimer(live_output_options['interval'],
                                                                         live_grapher[0].display, args=(curr_state,
-                                                                                                       curr_time,
+                                                                                                       total_time,
                                                                                                        trajectory_base,)
                                                                         )
                 display_timer.start()
@@ -126,19 +126,19 @@ class NumPySSASolver(GillesPySolver):
 
         return self.result, self.rc
 
-    def ___run(self, model, curr_state, curr_time, timeline, trajectory_base, live_grapher, t=20,
+    def ___run(self, model, curr_state, total_time, timeline, trajectory_base, live_grapher, t=20,
                number_of_trajectories=1, increment=0.05, seed=None, debug=False, show_labels=True, resume=None,
                timeout=None):
 
         try:
-            self.__run(model, curr_state, curr_time, timeline, trajectory_base, live_grapher, t, number_of_trajectories,
+            self.__run(model, curr_state, total_time, timeline, trajectory_base, live_grapher, t, number_of_trajectories,
                        increment, seed, debug, show_labels, resume, timeout)
         except Exception as e:
             self.has_raised_exception = e
             self.result = []
             return [], -1
 
-    def __run(self, model, curr_state, curr_time, timeline, trajectory_base, live_grapher, t=20,
+    def __run(self, model, curr_state, total_time, timeline, trajectory_base, live_grapher, t=20,
               number_of_trajectories=1, increment=0.05, seed=None, debug=False, show_labels=True,
               resume=None,  timeout=None):
 
@@ -206,6 +206,12 @@ class NumPySSASolver(GillesPySolver):
             trajectory = trajectory_base[trajectory_num]
             entry_count = 1
             curr_state[0] = {}
+            # curr_time and curr_state are list of len 1 so that __run receives reference
+            if resume is not None:
+                curr_time = [resume['time'][-1]]
+            else:
+                curr_time = [0]
+
 
             for spec in model.listOfSpecies:
                 if resume is not None:
@@ -242,6 +248,7 @@ class NumPySSASolver(GillesPySolver):
 
                 cumulative_sum = random.uniform(0, propensity_sum)
                 curr_time[0] += -math.log(random.random()) / propensity_sum
+                total_time[0] += -math.log(random.random()) / propensity_sum
                 if debug:
                     print('cumulative sum: ', cumulative_sum)
                     print('entry count: ', entry_count)

--- a/gillespy2/solvers/numpy/ssa_solver.py
+++ b/gillespy2/solvers/numpy/ssa_solver.py
@@ -77,7 +77,7 @@ class NumPySSASolver(GillesPySolver):
 
         # curr_time and curr_state are list of len 1 so that __run receives reference
         if resume is not None:
-            curr_time = [resume['time'][-1]]
+            total_time = [resume['time'][-1]]
         else:
             total_time = [0]
         curr_state = [None]
@@ -211,6 +211,7 @@ class NumPySSASolver(GillesPySolver):
                 curr_time = [resume['time'][-1]]
             else:
                 curr_time = [0]
+
 
 
             for spec in model.listOfSpecies:

--- a/gillespy2/solvers/numpy/tau_leaping_solver.py
+++ b/gillespy2/solvers/numpy/tau_leaping_solver.py
@@ -131,7 +131,7 @@ class TauLeapingSolver(GillesPySolver):
                                                                                         )
             # curr_time and curr_state are list of len 1 so that __run receives reference
             if resume is not None:
-                curr_time = [resume['time'][-1]]
+                total_time = [resume['time'][-1]]
             else:
                 total_time = [0]
 
@@ -241,7 +241,8 @@ class TauLeapingSolver(GillesPySolver):
             curr_state[0] = {}
 
             if resume is not None:
-                save_time = curr_time[0]
+                save_time = total_time[0]
+                curr_time = [save_time]
             else:
                 save_time = 0
                 curr_time = [0]

--- a/gillespy2/solvers/numpy/tau_leaping_solver.py
+++ b/gillespy2/solvers/numpy/tau_leaping_solver.py
@@ -129,17 +129,16 @@ class TauLeapingSolver(GillesPySolver):
             trajectory_base, tempSpecies = nputils.numpy_trajectory_base_initialization(model, number_of_trajectories,
                                                                                         timeline, species, resume=resume
                                                                                         )
-
             # curr_time and curr_state are list of len 1 so that __run receives reference
             if resume is not None:
                 curr_time = [resume['time'][-1]]
             else:
-                curr_time = [0]
+                total_time = [0]
 
             curr_state = [None]
             live_grapher = [None]
 
-            sim_thread = Thread(target=self.___run, args=(model, curr_state, curr_time, timeline, trajectory_base,
+            sim_thread = Thread(target=self.___run, args=(model, curr_state, total_time, timeline, trajectory_base,
                                                           live_grapher,), kwargs={'t': t,
                                                                                   'number_of_trajectories':
                                                                                       number_of_trajectories,
@@ -161,7 +160,7 @@ class TauLeapingSolver(GillesPySolver):
                     live_grapher[0] = liveGraphing.LiveDisplayer(model, timeline, number_of_trajectories,
                                                                  live_output_options, resume=resumeTest)
                     display_timer = liveGraphing.RepeatTimer(live_output_options['interval'], live_grapher[0].display,
-                                                                        args=(curr_state, curr_time, trajectory_base,))
+                                                                        args=(curr_state, total_time, trajectory_base,))
                     display_timer.start()
 
                 sim_thread.join(timeout=timeout)
@@ -181,12 +180,12 @@ class TauLeapingSolver(GillesPySolver):
                 raise self.has_raised_exception
             return self.result, self.rc
 
-    def ___run(self, model, curr_state,curr_time, timeline, trajectory_base, live_grapher, t=20,
+    def ___run(self, model, curr_state,total_time, timeline, trajectory_base, live_grapher, t=20,
                number_of_trajectories=1, increment=0.05, seed=None, debug=False, profile=False, show_labels=True,
                timeout=None, resume=None, tau_tol=0.03, **kwargs):
 
         try:
-            self.__run(model, curr_state, curr_time, timeline, trajectory_base, live_grapher, t, number_of_trajectories,
+            self.__run(model, curr_state, total_time, timeline, trajectory_base, live_grapher, t, number_of_trajectories,
                        increment, seed, debug, profile, timeout, resume, tau_tol, **kwargs)
 
         except Exception as e:
@@ -194,7 +193,7 @@ class TauLeapingSolver(GillesPySolver):
             self.result = []
             return [], -1
 
-    def __run(self, model, curr_state, curr_time, timeline, trajectory_base, live_grapher, t=20,
+    def __run(self, model, curr_state, total_time, timeline, trajectory_base, live_grapher, t=20,
               number_of_trajectories=1, increment=0.05, seed=None, debug=False, profile=False, timeout=None,
               resume=None, tau_tol=0.03, **kwargs):
 
@@ -240,10 +239,12 @@ class TauLeapingSolver(GillesPySolver):
             start_state = [0] * (len(model.listOfReactions) + len(model.listOfRateRules))
             propensities = {}
             curr_state[0] = {}
+
             if resume is not None:
                 save_time = curr_time[0]
             else:
                 save_time = 0
+                curr_time = [0]
 
             curr_state[0]['vol'] = model.volume
             data = { 'time': timeline}
@@ -345,6 +346,7 @@ class TauLeapingSolver(GillesPySolver):
                             start_state = prev_start_state.copy()
                             curr_state[0] = prev_curr_state.copy()
                             curr_time[0] = prev_curr_time
+                            total_time[0] = prev_curr_time
                             tau_step = tau_step / 2
                             steps_rejected += 1
                             if debug:


### PR DESCRIPTION
- Multiple trajectories were failing due to time not being reset for NumPySSASolvers and TauLeaping solvers

- curr_time is not reset for each trajectory, and live_graphing now keeps track of total simulation time through a variable 'total_time'