### PR TITLE
fix for unnamed reaction orders and seeding

### DIFF
--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -398,9 +398,18 @@ class Model(SortableObject):
             try:
                 reactions.verify()
                 self.validate_reactants_and_products(reactions)
-                if reactions.name in self.listOfReactions:
-                    raise ModelError("Duplicate name of reaction: {0}".format(reactions.name))
-                self.listOfReactions[reactions.name] = reactions
+                if reactions.name is None or reactions.name == '':
+                    i = 0
+                    while True:
+                        if 'reaction{}'.format(i) in self.listOfReactions:
+                            i += 1
+                        else:
+                            self.listOfReactions['reaction{}'.format(i)] = reactions
+                            break
+                else:
+                    if reactions.name in self.listOfReactions:
+                        raise ModelError("Duplicate name of reaction: {0}".format(reactions.name))
+                    self.listOfReactions[reactions.name] = reactions
                 # Build Sanitized reaction as well
                 sanitized_reaction = Reaction(name='R{}'.format(len(self._listOfReactions)))
                 sanitized_reaction.reactants = {self._listOfSpecies[species.name]: reactions.reactants[species] for

--- a/gillespy2/core/reaction.py
+++ b/gillespy2/core/reaction.py
@@ -37,6 +37,10 @@ class Reaction(SortableObject):
 
     Mass-action reactions must also have a rate term added. Note that the input
     rate represents the mass-action constant rate independent of volume.
+
+    if a name is not provided for reactions, the name will be populated by the
+    model based on the order it was added. This could impact seeded simulation 
+    results if the order of addition is not preserved.
     """
 
     def __init__(self, name="", reactants={}, products={}, propensity_function=None, massaction=False, rate=None,

--- a/gillespy2/core/reaction.py
+++ b/gillespy2/core/reaction.py
@@ -46,10 +46,7 @@ class Reaction(SortableObject):
         """
 
         # Metadata
-        if name == "" or name is None:
-            self.name = 'rxn' + str(uuid.uuid4()).replace('-', '_')
-        else:
-            self.name = name
+        self.name = name
         self.annotation = ""
 
         # We might use this flag in the future to automatically generate

--- a/test/test_all_solvers.py
+++ b/test/test_all_solvers.py
@@ -58,6 +58,20 @@ class TestAllSolvers(unittest.TestCase):
             diff_results = self.model.run(solver=solver, seed=2)
             self.assertFalse(np.array_equal(diff_results.to_array(),same_results.to_array()))
     
+    def test_random_seed_unnamed_reactions(self):
+        model = self.model
+        k2 = gillespy2.Parameter(name='k2', expression=1.0)
+        model.add_parameter([k2])
+        unnamed_rxn = gillespy2.Reaction(reactants={}, products={'Sp':1}, rate=k2)
+        model.add_reaction(unnamed_rxn)
+        for solver in self.solvers:
+            same_results = self.model.run(solver=solver, seed=1)
+            compare_results = self.model.run(solver=solver,seed=1)
+            self.assertTrue(np.array_equal(same_results.to_array(), compare_results.to_array()))
+            if solver.name == 'ODESolver': continue
+            diff_results = self.model.run(solver=solver, seed=2)
+            self.assertFalse(np.array_equal(diff_results.to_array(),same_results.to_array()))
+
     def test_extraneous_args(self):
         for solver in self.solvers:
             with self.assertLogs(level='WARN'):


### PR DESCRIPTION
took out UUID name creation and replaced with indexed naming when added to model for reactions fix for #409