### PR TITLE
Fix for issue #429, unselecting a species using plotly graphs will now vanish ALL trajectories

### DIFF
--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -42,7 +42,7 @@ def _plotplotly_iterate(trajectory, show_labels=True, trace_list=None, line_dict
 
     import plotly.graph_objs as go
 
-    for i,species in enumerate(trajectory.data):
+    for i, species in enumerate(trajectory.data):
         if species != 'time':
 
             if species not in included_species_list and included_species_list:
@@ -61,7 +61,8 @@ def _plotplotly_iterate(trajectory, show_labels=True, trace_list=None, line_dict
                         y=trajectory.data[species],
                         mode='lines',
                         name=species,
-                        line = line_dict
+                        line=line_dict,
+                        legendgroup=species
                     )
                 )
             else:
@@ -72,6 +73,7 @@ def _plotplotly_iterate(trajectory, show_labels=True, trace_list=None, line_dict
                         mode='lines',
                         name=species,
                         line=line_dict,
+                        legendgroup=species,
                         showlegend=False
                     )
                 )
@@ -431,6 +433,7 @@ class Results(UserList):
                 else:
                     trace_list = _plotplotly_iterate(trajectory, trace_list=trace_list, included_species_list=
                     included_species_list)
+
 
             layout = go.Layout(
                 showlegend=show_legend,


### PR DESCRIPTION
- Fix on line 76 of results.py, species were never added to a legend group, leading to unexpected behavior. When each species belongs to the SAME legend group (i.e, the name displayed on the legend, ex: substrate), and you click on that "name" or "legend group" on the legend, all members of that legend group will disappear as expected 